### PR TITLE
Cache DOS colours and re-use them

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import unittest
 
 def load_test_suite():
     test_loader = unittest.TestLoader()
-    test_suite = test_loader.discover('tests/tests_symmetry')
+    test_suite = test_loader.discover('tests', pattern='test*.py')
     return test_suite
 
 with open('README.rst', 'r') as file:

--- a/sumo/plotting/__init__.py
+++ b/sumo/plotting/__init__.py
@@ -20,6 +20,8 @@ default_colours = [[240, 163, 255], [0, 117, 220], [153, 63, 0], [76, 0, 92],
                    [148, 255, 181], [143, 124, 0], [255, 168, 187],
                    [128, 128, 128]]
 
+colour_cache = {}
+
 default_fonts = ['Whitney Book Extended', 'Arial', 'Whitney Book', 'Helvetica',
                  'Liberation Sans', 'Andale Sans']
 

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -288,6 +288,10 @@ def get_colour_for_element_and_orbital(element, orbital, colours=None):
     will be used based on the list of 22 colours of maximum contast:
     http://www.iscc.org/pdf/PC54_1724_001.pdf
 
+    This is cached in sumo.plotting.colour_cache and re-used for subsequent
+    plots within this Python instance. To reset the cache, set
+    ``sumo.plotting.colour_cache = {}``.
+
     Args:
         element (str): The element.
         orbital (str): The orbital.

--- a/tests/tests_plotting/test_dos_plotter.py
+++ b/tests/tests_plotting/test_dos_plotter.py
@@ -1,0 +1,69 @@
+from __future__ import division
+
+import unittest
+from os.path import abspath
+from pkg_resources import Requirement, resource_filename
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
+from sumo.plotting import colour_cycle, default_colours
+import sumo.plotting.dos_plotter
+from sumo.plotting.dos_plotter import get_colour_for_element_and_orbital
+
+
+class GetColourTestCase(unittest.TestCase):
+    def setUp(self):
+        # Reboot the colour cycle for consistency
+        sumo.plotting.dos_plotter.col_cycle = colour_cycle()
+
+        # Open default CLI colours config
+        config_path = resource_filename(Requirement.parse('sumo'),
+                                        'sumo/plotting/orbital_colours.conf')
+
+        self.config = configparser.ConfigParser()
+        self.config.read(abspath(config_path))
+
+    def test_get_colour_cache(self):
+        """Check colour caching"""
+        col1 = tuple(get_colour_for_element_and_orbital('Hf', 's'))
+        col2 = tuple(get_colour_for_element_and_orbital('Zr', 'd'))
+        col3 = tuple(get_colour_for_element_and_orbital('Hf', 's'))
+
+        self.assertEqual(col1, col3)
+        self.assertNotEqual(col1, col2)
+
+    def test_get_colour_type_error(self):
+        """Check bogus colour info is rejected"""
+        with self.assertRaises(TypeError):
+            get_colour_for_element_and_orbital('Na', 'p', colours=('#aabbcc'))
+
+    def test_get_colour_config(self):
+        """Check orbital colours from config file"""
+        col_O_p = get_colour_for_element_and_orbital('O', 'p',
+                                                     colours=self.config)
+        col_Re_d = get_colour_for_element_and_orbital('Re', 'd',
+                                                      colours=self.config)
+
+        self.assertEqual(col_O_p, '#0DB14B')
+        self.assertEqual(col_Re_d, '#A154A1')
+
+    def test_get_colour_mixed(self):
+        """Check new colours drawn in correct sequence"""
+        col_O_p = get_colour_for_element_and_orbital('O', 'p',
+                                                     colours=self.config)
+        col_Hf_s = get_colour_for_element_and_orbital('Hf', 's',
+                                                      colours=self.config)
+        col_Re_d = get_colour_for_element_and_orbital('Re', 'd',
+                                                      colours=self.config)
+        col_Zr_d = get_colour_for_element_and_orbital('Zr', 'd',
+                                                      colours=self.config)
+
+        default_0 = tuple([x / 255 for x in default_colours[0]])
+        default_1 = tuple([x / 255 for x in default_colours[1]])
+        self.assertEqual(tuple(col_Hf_s), default_0)
+        self.assertEqual(tuple(col_Zr_d), default_1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This addresses #8 by ensuring that orbital colours will be consistent across multiplots and between re-plot calls from an interactive notebook.

A dict  `sumo.plotting.colour_cache` is held at the plotting level (as other plots may wish to share this information) and initialised as `{}`; when the dos_plotter does not find an orbital colour specified in the ``colours`` argument it will take the next item from a cycle and update the cache with `{element: {orbital: colour}}`. To clear the cache and start the colour cycle from the beginning, this module-level variable can be manually reset to `{}`. This would rarely be necessary: I still recommend that any real colour tweaking should be done by passing a dict or config directly.

Tests are included and currently pass.