### PR TITLE
Axis labels

### DIFF
--- a/sumo/cli/bandplot.py
+++ b/sumo/cli/bandplot.py
@@ -47,6 +47,7 @@ __date__ = "July 18, 2017"
 def bandplot(filenames=None, prefix=None, directory=None, vbm_cbm_marker=False,
              projection_selection=None, mode='rgb',
              interpolate_factor=4, circle_size=150, dos_file=None,
+             ylabel='Energy (eV)', dos_label=None,
              elements=None, lm_orbitals=None, atoms=None,
              total_only=False, plot_total=True, legend_cutoff=3, gaussian=None,
              height=6., width=6., ymin=-6., ymax=6., colours=None, yscale=1,
@@ -240,13 +241,16 @@ def bandplot(filenames=None, prefix=None, directory=None, vbm_cbm_marker=False,
                                          zero_to_efermi=True, ymin=ymin,
                                          ymax=ymax, height=height, width=width,
                                          vbm_cbm_marker=vbm_cbm_marker,
-                                         plt=plt, dos_plotter=dos_plotter,
-                                         dos_options=dos_opts, fonts=fonts)
+                                         ylabel=ylabel, plt=plt,
+                                         dos_plotter=dos_plotter,
+                                         dos_options=dos_opts,
+                                         dos_label=dos_label, fonts=fonts)
     else:
         plt = plotter.get_plot(zero_to_efermi=True, ymin=ymin, ymax=ymax,
                                height=height, width=width,
-                               vbm_cbm_marker=vbm_cbm_marker, plt=plt,
-                               dos_plotter=dos_plotter, dos_options=dos_opts,
+                               vbm_cbm_marker=vbm_cbm_marker,
+                               ylabel=ylabel, plt=plt, dos_plotter=dos_plotter,
+                               dos_options=dos_opts, dos_label=dos_label,
                                fonts=fonts)
 
     if save_files:
@@ -396,6 +400,11 @@ def _get_parser():
                         dest='circle_size', metavar='S',
                         help=('circle size for "stacked" projections '
                               '(default: 150)'))
+    parser.add_argument('--ylabel', type=str, default='Energy (eV)',
+                        help='y-axis (i.e. energy) label/units')
+    parser.add_argument('--dos-label', type=str, dest='dos_label',
+                        default=None,
+                        help='Axis label for DOS if included')
     parser.add_argument('--dos', default=None,
                         help='path to density of states vasprun.xml')
     parser.add_argument('--elements', type=_el_orb, metavar='E',
@@ -464,6 +473,7 @@ def main():
              projection_selection=args.projection_selection, mode=args.mode,
              interpolate_factor=args.interpolate_factor,
              circle_size=args.circle_size, yscale=args.scale,
+             ylabel=args.ylabel, dos_label=args.dos_label,
              dos_file=args.dos, elements=args.elements,
              lm_orbitals=args.orbitals, atoms=args.atoms,
              total_only=args.total_only, plot_total=args.total,

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -42,6 +42,7 @@ def dosplot(filename=None, prefix=None, directory=None, elements=None,
             total_only=False, plot_total=True, legend_on=True,
             legend_frame_on=False, legend_cutoff=3., gaussian=None, height=6.,
             width=8., xmin=-6., xmax=6., num_columns=2, colours=None, yscale=1,
+            xlabel='Energy (eV)', ylabel='Arb. units',
             image_format='pdf', dpi=400, plt=None, fonts=None):
     """A script to plot the density of states from a vasprun.xml file.
 
@@ -124,6 +125,8 @@ def dosplot(filename=None, prefix=None, directory=None, elements=None,
 
             The colour can be a hex code, series of rgb value, or any other
             format supported by matplotlib.
+        xlabel (:obj:`str`, optional): Label/units for x-axis (i.e. energy)
+        ylabel (:obj:`str`, optional): Label/units for y-axis (i.e. DOS)
         yscale (:obj:`float`, optional): Scaling factor for the y-axis.
         image_format (:obj:`str`, optional): The image file format. Can be any
             format supported by matplot, including: png, jpg, pdf, and svg.
@@ -159,6 +162,7 @@ def dosplot(filename=None, prefix=None, directory=None, elements=None,
                            colours=colours, plot_total=plot_total,
                            legend_on=legend_on, num_columns=num_columns,
                            legend_frame_on=legend_frame_on,
+                           xlabel=xlabel, ylabel=ylabel,
                            legend_cutoff=legend_cutoff, dpi=dpi, plt=plt,
                            fonts=fonts)
 
@@ -277,6 +281,10 @@ def _get_parser():
                         help='maximum energy on the x-axis')
     parser.add_argument('--config', type=str, default=None,
                         help='colour configuration file')
+    parser.add_argument('--xlabel', type=str, default='Energy (eV)',
+                        help='x-axis (i.e. energy) label/units'),
+    parser.add_argument('--ylabel', type=str, default='Arb. units',
+                        help='y-axis (i.e. DOS) label/units'),
     parser.add_argument('--yscale', type=float, default=1,
                         help='scaling factor for the y-axis')
     parser.add_argument('--format', type=str, default='pdf',
@@ -320,6 +328,7 @@ def main():
             legend_cutoff=args.legend_cutoff, gaussian=args.gaussian,
             height=args.height, width=args.width, xmin=args.xmin,
             xmax=args.xmax, num_columns=args.columns, colours=colours,
+            xlabel=args.xlabel, ylabel=args.ylabel,
             yscale=args.yscale, image_format=args.image_format, dpi=args.dpi,
             fonts=[args.font])
 

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -45,8 +45,11 @@ class SBSPlotter(BSPlotter):
         BSPlotter.__init__(self, bs)
 
     def get_plot(self, zero_to_efermi=True, ymin=-6., ymax=6.,
-                 width=6., height=6., vbm_cbm_marker=False, dpi=400, plt=None,
-                 dos_plotter=None, dos_options=None, dos_aspect=3, fonts=None):
+                 width=6., height=6., vbm_cbm_marker=False,
+                 ylabel='Energy (eV)',
+                 dpi=400, plt=None,
+                 dos_plotter=None, dos_options=None, dos_label=None,
+                 dos_aspect=3, fonts=None):
         """Get a :obj:`matplotlib.pyplot` object of the band structure.
 
         If the system is spin polarised, blue lines are spin up, red lines are
@@ -63,14 +66,15 @@ class SBSPlotter(BSPlotter):
             height (:obj:`float`, optional): The height of the plot.
             vbm_cbm_marker (:obj:`bool`, optional): Plot markers to indicate
                 the VBM and CBM locations.
+            ylabel (:obj:`str`, optional): y-axis (i.e. energy) label/units
             dpi (:obj:`int`, optional): The dots-per-inch (pixel density) for
                 the image.
             plt (:obj:`matplotlib.pyplot`, optional): A
                 :obj:`matplotlib.pyplot` object to use for plotting.
-            dos_plotter (:obj:`~sumo.plotting.dos_plotter.VDOSPlotter`, \
+            dos_plotter (:obj:`~sumo.plotting.dos_plotter.SDOSPlotter`, \
                 optional): Plot the density of states alongside the band
                 structure. This should be a
-                :obj:`~sumo.plotting.dos_plotter.VDOSPlotter` object
+                :obj:`~sumo.plotting.dos_plotter.SDOSPlotter` object
                 initialised with the data to plot.
             dos_options (:obj:`dict`, optional): The options for density of
                 states plotting. This should be formatted as a :obj:`dict`
@@ -108,6 +112,7 @@ class SBSPlotter(BSPlotter):
                         Plot the density of states for each element on seperate
                         subplots. Defaults to ``False``.
 
+            dos_label (:obj:`str`, optional): DOS axis label/unitsa
             dos_aspect (:obj:`float`, optional): Aspect ratio for the band
                 structure and density of states subplot. For example,
                 ``dos_aspect = 3``, results in a ratio of 3:1, for the band
@@ -157,18 +162,21 @@ class SBSPlotter(BSPlotter):
                 e = eners[nd][str(Spin.down)][nb]
                 ax.plot(dists[nd], e, 'r--', linewidth=band_linewidth)
 
-        self._maketicks(ax)
+        self._maketicks(ax, ylabel=ylabel)
         self._makeplot(ax, plt.gcf(), data, zero_to_efermi=zero_to_efermi,
                        vbm_cbm_marker=vbm_cbm_marker, width=width,
                        height=height, ymin=ymin, ymax=ymax,
-                       dos_plotter=dos_plotter, dos_options=dos_options)
+                       dos_plotter=dos_plotter, dos_options=dos_options,
+                       dos_label=dos_label)
         return plt
 
     def get_projected_plot(self, selection, mode='rgb', interpolate_factor=4,
                            circle_size=150, projection_cutoff=0.001,
                            zero_to_efermi=True, ymin=-6., ymax=6., width=6.,
-                           height=6., vbm_cbm_marker=False, dpi=400, plt=None,
-                           dos_plotter=None, dos_options=None,
+                           height=6., vbm_cbm_marker=False,
+                           ylabel='Energy (eV)',
+                           dpi=400, plt=None,
+                           dos_plotter=None, dos_options=None, dos_label=None,
                            dos_aspect=3, fonts=None):
         """Get a :obj:`matplotlib.pyplot` of the projected band structure.
 
@@ -234,14 +242,15 @@ class SBSPlotter(BSPlotter):
             height (:obj:`float`, optional): The height of the plot.
             vbm_cbm_marker (:obj:`bool`, optional): Plot markers to indicate
                 the VBM and CBM locations.
+            ylabel (:obj:`str`, optional): y-axis (i.e. energy) label/units
             dpi (:obj:`int`, optional): The dots-per-inch (pixel density) for
                 the image.
             plt (:obj:`matplotlib.pyplot`, optional): A
                 :obj:`matplotlib.pyplot` object to use for plotting.
-            dos_plotter (:obj:`~sumo.plotting.dos_plotter.VDOSPlotter`, \
+            dos_plotter (:obj:`~sumo.plotting.dos_plotter.SDOSPlotter`, \
                 optional): Plot the density of states alongside the band
                 structure. This should be a
-                :obj:`~sumo.plotting.dos_plotter.VDOSPlotter` object
+                :obj:`~sumo.plotting.dos_plotter.SDOSPlotter` object
                 initialised with the data to plot.
             dos_options (:obj:`dict`, optional): The options for density of
                 states plotting. This should be formatted as a :obj:`dict`
@@ -279,6 +288,7 @@ class SBSPlotter(BSPlotter):
                         Plot the density of states for each element on seperate
                         subplots. Defaults to ``False``.
 
+            dos_label (:obj:`str`, optional): DOS axis label/units
             fonts (:obj:`list`, optional): Fonts to use in the plot. Can be a
                 a single font, specified as a :obj:`str`, or several fonts,
                 specified as a :obj:`list` of :obj:`str`.
@@ -388,16 +398,17 @@ class SBSPlotter(BSPlotter):
                   scatterpoints=1)
 
         # finish and tidy plot
-        self._maketicks(ax)
+        self._maketicks(ax, ylabel=ylabel)
         self._makeplot(ax, plt.gcf(), data, zero_to_efermi=zero_to_efermi,
                        vbm_cbm_marker=vbm_cbm_marker, width=width,
                        height=height, ymin=ymin, ymax=ymax,
-                       dos_plotter=dos_plotter, dos_options=dos_options)
+                       dos_plotter=dos_plotter, dos_options=dos_options,
+                       dos_label=dos_label)
         return plt
 
     def _makeplot(self, ax, fig, data, zero_to_efermi=True,
                   vbm_cbm_marker=False, ymin=-6., ymax=6., height=6., width=6.,
-                  dos_plotter=None, dos_options=None):
+                  dos_plotter=None, dos_options=None, dos_label=None):
         """Tidy the band structure & add the density of states if required."""
         # draw line at Fermi level if not zeroing to e-Fermi
         if not zero_to_efermi:
@@ -424,15 +435,15 @@ class SBSPlotter(BSPlotter):
                 dos_options = {}
 
             dos_options.update({'xmin': ymin, 'xmax': ymax})
-            self._makedos(ax, dos_plotter, dos_options)
+            self._makedos(ax, dos_plotter, dos_options, dos_label=dos_label)
         else:
             # keep correct aspect ratio square
             x0, x1 = ax.get_xlim()
             y0, y1 = ax.get_ylim()
             ax.set_aspect((height/width) * ((x1-x0)/(y1-y0)))
 
-    def _makedos(self, ax, dos_plotter, dos_options):
-        """This is basically the same as the VDOSPlotter get_plot function."""
+    def _makedos(self, ax, dos_plotter, dos_options, dos_label=None):
+        """This is basically the same as the SDOSPlotter get_plot function."""
 
         plot_data = dos_plotter.dos_plot_data(**dos_options)
 
@@ -464,11 +475,15 @@ class SBSPlotter(BSPlotter):
             ax.tick_params(axis='x', which='both', labelbottom='off',
                            labeltop='off', bottom='off', top='off')
 
+            if dos_label is not None:
+                ax.yaxis.set_label_position('right')
+                ax.set_ylabel(dos_label, rotation=270, labelpad=label_size)
+
             ax.legend(loc=2, frameon=False, ncol=1,
                       prop={'size': label_size - 3},
                       bbox_to_anchor=(1., 1.))
 
-    def _maketicks(self, ax):
+    def _maketicks(self, ax, ylabel='Energy (eV)'):
         """Utility method to add tick marks to a band structure."""
         # set y-ticks
         ax.yaxis.set_major_locator(MaxNLocator(6))
@@ -494,4 +509,4 @@ class SBSPlotter(BSPlotter):
         ax.set_xticks(unique_d)
         ax.set_xticklabels(unique_l)
         ax.xaxis.grid(True, c='k', ls='-', lw=line_width)
-        ax.set_ylabel('Energy (eV)')
+        ax.set_ylabel(ylabel)

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -476,8 +476,7 @@ class SBSPlotter(BSPlotter):
                            labeltop='off', bottom='off', top='off')
 
             if dos_label is not None:
-                ax.yaxis.set_label_position('right')
-                ax.set_ylabel(dos_label, rotation=270, labelpad=label_size)
+                ax.set_xlabel(dos_label)
 
             ax.legend(loc=2, frameon=False, ncol=1,
                       prop={'size': label_size - 3},

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -167,6 +167,7 @@ class SDOSPlotter(object):
     def get_plot(self, subplot=False, width=6., height=8., xmin=-6., xmax=6.,
                  yscale=1, colours=None, plot_total=True, legend_on=True,
                  num_columns=2, legend_frame_on=False, legend_cutoff=3,
+                 xlabel='Energy (eV)', ylabel='Arb. units',
                  dpi=400, fonts=None, plt=None):
         """Get a :obj:`matplotlib.pyplot` object of the density of states.
 
@@ -202,6 +203,8 @@ class SDOSPlotter(object):
                 elemental orbital to be labelled in the legend. This prevents
                 the legend from containing labels for orbitals that have very
                 little contribution in the plotting range.
+            xlabel (:obj:`str`, optional): Label/units for x-axis (i.e. energy)
+            ylabel (:obj:`str`, optional): Label/units for y-axis (i.e. DOS)
             dpi (:obj:`int`, optional): The dots-per-inch (pixel density) for
                 the image.
             fonts (:obj:`list`, optional): Fonts to use in the plot. Can be a
@@ -267,15 +270,15 @@ class SDOSPlotter(object):
 
         # no add axis labels and sort out ticks
         if subplot:
-            ax.set_xlabel('Energy (eV)', fontsize=label_size)
+            ax.set_xlabel(xlabel, fontsize=label_size)
             fig.subplots_adjust(hspace=0)
             plt.setp([a.get_xticklabels() for a in fig.axes[:-1]],
                      visible=False)
-            fig.text(0.08, 0.5, 'Arb.units', fontsize=label_size, ha='left',
+            fig.text(0.08, 0.5, ylabel, fontsize=label_size, ha='left',
                      va='center', rotation='vertical', transform=ax.transAxes)
         else:
-            ax.set_xlabel('Energy (eV)')
-            ax.set_ylabel('Arb.units')
+            ax.set_xlabel(xlabel)
+            ax.set_ylabel(ylabel)
 
         return plt
 


### PR DESCRIPTION
Addresses #9 by providing: `--xlabel` and `--ylabel` options for _dosplot_; `--ylabel` and `--dos-label` for _bandplot_.

`--dos-label` looks a bit cramped right next to the legend there, so I'm happy to leave `None` as the default. This seems most useful with `--total-only`, if only there was a way to disable the legend.