### PR TITLE
Implement combined phonon band structure and dos plotting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Enhancements by Adam Jackson:
 
 Various bug fixes:
 
-- Fixed gaussian broadening of DOS
+- Fixed for ``--symprec`` in phonon-bandplot.
+- Fixed gaussian broadening of DOS.
 - Fixed ``--spg`` option in kgen and phonon-bandplot.
 - Fixed default arguments for band structure + dos plotting.
 - Added A centered orthorhombic lattice to ``BradCrackKpath``.

--- a/sumo/cli/phonon_bandplot.py
+++ b/sumo/cli/phonon_bandplot.py
@@ -53,7 +53,7 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
                     symprec=0.01, mode='bradcrack', kpt_list=None,
                     eigenvectors=False, labels=None, height=6., width=6.,
                     ymin=None, ymax=None, image_format='pdf', dpi=400,
-                    plt=None, fonts=None, dos_file=None):
+                    plt=None, fonts=None, dos=None):
     """A script to plot phonon band structure diagrams.
 
     Args:
@@ -114,7 +114,7 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
             A -> Z will be used instead.
         eigenvectors (:obj:`bool`, optional): Write the eigenvectors to the
             yaml file.
-        dos_file (str): Path to Phonopy total dos .dat file
+        dos (str): Path to Phonopy total dos .dat file
         height (:obj:`float`, optional): The height of the plot.
         width (:obj:`float`, optional): The width of the plot.
         ymin (:obj:`float`, optional): The minimum energy on the y-axis.
@@ -199,7 +199,7 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
 
     plotter = SPhononBSPlotter(bs)
     plt = plotter.get_plot(ymin=ymin, ymax=ymax, height=height, width=width,
-                           plt=plt, fonts=fonts, dos_file=dos_file)
+                           plt=plt, fonts=fonts, dos=dos)
 
     if save_files:
         basename = 'phonon_band.{}'.format(image_format)
@@ -308,7 +308,7 @@ def _get_parser():
     parser.add_argument('--dpi', type=int, default=400,
                         help='pixel density for image file')
     parser.add_argument('--font', default=None, help='font to use')
-    parser.add_argument('--dos-file', type=str, dest='dos_file', default=None,
+    parser.add_argument('--dos', type=str, dest='dos', default=None,
                         help='Phonopy .dat file for phonon DOS')
     return parser
 
@@ -365,7 +365,7 @@ def main():
                     height=args.height, width=args.width, ymin=args.ymin,
                     ymax=args.ymax, image_format=args.image_format,
                     dpi=args.dpi, fonts=[args.font],
-                    eigenvectors=args.eigenvectors, dos_file=args.dos_file)
+                    eigenvectors=args.eigenvectors, dos=args.dos)
 
 
 if __name__ == "__main__":

--- a/sumo/cli/phonon_bandplot.py
+++ b/sumo/cli/phonon_bandplot.py
@@ -356,7 +356,7 @@ def main():
 
     phonon_bandplot(args.filename, poscar=args.poscar, prefix=args.prefix,
                     directory=args.directory, dim=dim, born=args.born,
-                    qmesh=args.qmesh, primitive_axis=pa,
+                    qmesh=args.qmesh, primitive_axis=pa, symprec=args.symprec,
                     spg=spg, line_density=args.density,
                     mode=mode, kpt_list=kpoints, labels=labels,
                     height=args.height, width=args.width, ymin=args.ymin,

--- a/sumo/plotting/phonon_bs_plotter.py
+++ b/sumo/plotting/phonon_bs_plotter.py
@@ -39,7 +39,8 @@ class SPhononBSPlotter(PhononBSPlotter):
     def _plot_phonon_dos(self, dos_file, ax=None):
         if ax is None:
             ax = plt.gca()
-        y, x = np.genfromtxt('total_dos.csv', delimiter=',', unpack=True)
+        dat = np.genfromtxt(dos_file, comments='#')
+        y, x = dat[:, 0], dat[:, 1]
         ax.plot(x, y, '-', color='#3953A4')
         ax.fill_betweenx(y, x, 0, color='#3953A4', alpha=0.5)
         ax.set_xticks([])

--- a/sumo/plotting/phonon_bs_plotter.py
+++ b/sumo/plotting/phonon_bs_plotter.py
@@ -41,8 +41,7 @@ class SPhononBSPlotter(PhononBSPlotter):
             ax = plt.gca()
         if color is None:
             color = 'C0'
-        dat = np.genfromtxt(dos, comments='#')
-        y, x = dat[:, 0], dat[:, 1]
+        y, x = dos[:, 0], dos[:, 1]
         ax.plot(x, y, '-', color=color)
         ax.fill_betweenx(y, x, 0, color=color, alpha=0.5)
         ax.set_xticks([])
@@ -66,7 +65,7 @@ class SPhononBSPlotter(PhononBSPlotter):
                 specified as a :obj:`list` of :obj:`str`.
             plt (:obj:`matplotlib.pyplot`, optional): A
                 :obj:`matplotlib.pyplot` object to use for plotting.
-            dos (str): Path to total dos .csv data
+            dos (:obj:`np.ndarray`): 2D Numpy array of total DOS data
             dos_aspect (float): Width division for vertical DOS
             color (:obj:`str` or :obj:`tuple`, optional): Line/fill colour in
                 any matplotlib-accepted format
@@ -76,11 +75,11 @@ class SPhononBSPlotter(PhononBSPlotter):
         """
 
         if color is None:
-            color = 'C0' # Default to first colour in matplotlib series
+            color = 'C0'  # Default to first colour in matplotlib series
 
         if dos is not None:
-            plt = pretty_subplot(1, 2, width, height, sharex=False, sharey=True, dpi=dpi,
-                                 plt=plt, fonts=fonts,
+            plt = pretty_subplot(1, 2, width, height, sharex=False,
+                                 sharey=True, dpi=dpi, plt=plt, fonts=fonts,
                                  gridspec_kw={'width_ratios': [dos_aspect, 1],
                                               'wspace': 0})
             ax = plt.gcf().axes[0]
@@ -116,7 +115,7 @@ class SPhononBSPlotter(PhononBSPlotter):
         # Define colours
         grey = (0.5, 0.5, 0.5)
         if color is None:
-            color = 'C0' # Default to first colour in matplotlib series
+            color = 'C0'  # Default to first colour in matplotlib series
 
         # set x and y limits
         tymax = ymax if ymax else max(flatten(data['frequency']))

--- a/sumo/plotting/phonon_bs_plotter.py
+++ b/sumo/plotting/phonon_bs_plotter.py
@@ -40,7 +40,7 @@ class SPhononBSPlotter(PhononBSPlotter):
         if ax is None:
             ax = plt.gca()
         if color is None:
-            color = 'C0'
+            color = 'C2'
         y, x = dos[:, 0], dos[:, 1]
         ax.plot(x, y, '-', color=color)
         ax.fill_betweenx(y, x, 0, color=color, alpha=0.5)
@@ -75,7 +75,7 @@ class SPhononBSPlotter(PhononBSPlotter):
         """
 
         if color is None:
-            color = 'C0'  # Default to first colour in matplotlib series
+            color = 'C2'  # Default to first colour in matplotlib series
 
         if dos is not None:
             plt = pretty_subplot(1, 2, width, height, sharex=False,

--- a/sumo/plotting/phonon_bs_plotter.py
+++ b/sumo/plotting/phonon_bs_plotter.py
@@ -35,8 +35,18 @@ class SPhononBSPlotter(PhononBSPlotter):
         PhononBSPlotter.__init__(self, bs)
         self.imag_tol = imag_tol
 
+    def _plot_phonon_dos(dos_file, ax=None):
+        if ax is None:
+            ax = plt.gca()
+
+        y, x = np.loadtext('total_dos.csv', delimiter=',', unpack=True)
+        ax.plot(x, y, '-')
+        ax.fill_betweenx(y, x, 0)
+        ax.set_xticks([])
+        ax.set_xlim([0, max(x) * 1.1])
+
     def get_plot(self, ymin=None, ymax=None, width=6., height=6., dpi=400,
-                 plt=None, fonts=None):
+                 plt=None, fonts=None, dos_file=None, dos_aspect=3):
         """Get a :obj:`matplotlib.pyplot` object of the phonon band structure.
 
         Args:
@@ -51,12 +61,34 @@ class SPhononBSPlotter(PhononBSPlotter):
                 specified as a :obj:`list` of :obj:`str`.
             plt (:obj:`matplotlib.pyplot`, optional): A
                 :obj:`matplotlib.pyplot` object to use for plotting.
+            dos_file (str): Path to total dos .csv data
+            dos_aspect (float): Width division for vertical DOS
 
         Returns:
             :obj:`matplotlib.pyplot`: The phonon band structure plot.
         """
-        plt = pretty_plot(width, height, dpi=dpi, plt=plt, fonts=fonts)
-        ax = plt.gca()
+
+        # if dos_plotter:
+        #     plt = pretty_subplot(1, 2, width, height, sharex=False, dpi=dpi,
+        #                          plt=plt, fonts=fonts,
+        #                          gridspec_kw={'width_ratios': [dos_aspect, 1],
+        #                                       'wspace': 0})
+        #     ax = plt.gcf().axes[0]
+        # else:
+        #     plt = pretty_plot(width, height, dpi=dpi, plt=plt, fonts=fonts)
+        #     ax = plt.gca()
+
+
+        if dos_file:
+            plt = pretty_subplot(1, 2, width, height, sharex=False, dpi=dpi,
+                                 plt=plt, fonts=fonts,
+                                 gridspec_kw={'width_ratios': [dos_aspect, 1],
+                                              'wspace': 0})
+            _plot_phonon_dos(dos_file, ax=plt.gcf().axes[1])
+            ax = plt.gcf().axes[0]
+        else:
+            plt = pretty_plot(width, height, dpi=dpi, plt=plt, fonts=fonts)
+            ax = plt.gca()
 
         data = self.bs_plot_data()
         dists = data['distances']
@@ -75,6 +107,8 @@ class SPhononBSPlotter(PhononBSPlotter):
         self._makeplot(ax, plt.gcf(), data, width=width, height=height,
                        ymin=ymin, ymax=ymax)
         plt.tight_layout()
+        plt.subplots_adjust(wspace=0)
+
         return plt
 
     def _makeplot(self, ax, fig, data, ymin=None, ymax=None, height=6,

--- a/sumo/plotting/phonon_bs_plotter.py
+++ b/sumo/plotting/phonon_bs_plotter.py
@@ -36,12 +36,12 @@ class SPhononBSPlotter(PhononBSPlotter):
         PhononBSPlotter.__init__(self, bs)
         self.imag_tol = imag_tol
 
-    def _plot_phonon_dos(self, dos_file, ax=None, color=None):
+    def _plot_phonon_dos(self, dos, ax=None, color=None):
         if ax is None:
             ax = plt.gca()
         if color is None:
             color = 'C0'
-        dat = np.genfromtxt(dos_file, comments='#')
+        dat = np.genfromtxt(dos, comments='#')
         y, x = dat[:, 0], dat[:, 1]
         ax.plot(x, y, '-', color=color)
         ax.fill_betweenx(y, x, 0, color=color, alpha=0.5)
@@ -50,7 +50,7 @@ class SPhononBSPlotter(PhononBSPlotter):
         ax.set_xlabel("DOS")
 
     def get_plot(self, ymin=None, ymax=None, width=6., height=6., dpi=400,
-                 plt=None, fonts=None, dos_file=None, dos_aspect=3,
+                 plt=None, fonts=None, dos=None, dos_aspect=3,
                  color=None):
         """Get a :obj:`matplotlib.pyplot` object of the phonon band structure.
 
@@ -66,7 +66,7 @@ class SPhononBSPlotter(PhononBSPlotter):
                 specified as a :obj:`list` of :obj:`str`.
             plt (:obj:`matplotlib.pyplot`, optional): A
                 :obj:`matplotlib.pyplot` object to use for plotting.
-            dos_file (str): Path to total dos .csv data
+            dos (str): Path to total dos .csv data
             dos_aspect (float): Width division for vertical DOS
             color (:obj:`str` or :obj:`tuple`, optional): Line/fill colour in
                 any matplotlib-accepted format
@@ -78,7 +78,7 @@ class SPhononBSPlotter(PhononBSPlotter):
         if color is None:
             color = 'C0' # Default to first colour in matplotlib series
 
-        if dos_file:
+        if dos is not None:
             plt = pretty_subplot(1, 2, width, height, sharex=False, sharey=True, dpi=dpi,
                                  plt=plt, fonts=fonts,
                                  gridspec_kw={'width_ratios': [dos_aspect, 1],
@@ -103,14 +103,14 @@ class SPhononBSPlotter(PhononBSPlotter):
 
         self._maketicks(ax)
         self._makeplot(ax, plt.gcf(), data, width=width, height=height,
-                       ymin=ymin, ymax=ymax, dos_file=dos_file, color=color)
+                       ymin=ymin, ymax=ymax, dos=dos, color=color)
         plt.tight_layout()
         plt.subplots_adjust(wspace=0)
 
         return plt
 
     def _makeplot(self, ax, fig, data, ymin=None, ymax=None, height=6,
-                  width=6, dos_file=None, color=None):
+                  width=6, dos=None, color=None):
         """Utility method to tidy phonon band structure diagrams. """
 
         # Define colours
@@ -131,8 +131,8 @@ class SPhononBSPlotter(PhononBSPlotter):
         ax.set_xlim(0, data['distances'][-1][-1])
         ax.axhline(0, color=grey, linestyle='--')
 
-        if dos_file is not None:
-            self._plot_phonon_dos(dos_file, ax=fig.axes[1], color=color)
+        if dos is not None:
+            self._plot_phonon_dos(dos, ax=fig.axes[1], color=color)
         else:
 
             # keep correct aspect ratio square

--- a/sumo/plotting/phonon_bs_plotter.py
+++ b/sumo/plotting/phonon_bs_plotter.py
@@ -36,19 +36,22 @@ class SPhononBSPlotter(PhononBSPlotter):
         PhononBSPlotter.__init__(self, bs)
         self.imag_tol = imag_tol
 
-    def _plot_phonon_dos(self, dos_file, ax=None):
+    def _plot_phonon_dos(self, dos_file, ax=None, color=None):
         if ax is None:
             ax = plt.gca()
+        if color is None:
+            color = 'C0'
         dat = np.genfromtxt(dos_file, comments='#')
         y, x = dat[:, 0], dat[:, 1]
-        ax.plot(x, y, '-', color='#3953A4')
-        ax.fill_betweenx(y, x, 0, color='#3953A4', alpha=0.5)
+        ax.plot(x, y, '-', color=color)
+        ax.fill_betweenx(y, x, 0, color=color, alpha=0.5)
         ax.set_xticks([])
         ax.set_xlim([0, max(x) * 1.1])
         ax.set_xlabel("DOS")
 
     def get_plot(self, ymin=None, ymax=None, width=6., height=6., dpi=400,
-                 plt=None, fonts=None, dos_file=None, dos_aspect=3):
+                 plt=None, fonts=None, dos_file=None, dos_aspect=3,
+                 color=None):
         """Get a :obj:`matplotlib.pyplot` object of the phonon band structure.
 
         Args:
@@ -65,10 +68,15 @@ class SPhononBSPlotter(PhononBSPlotter):
                 :obj:`matplotlib.pyplot` object to use for plotting.
             dos_file (str): Path to total dos .csv data
             dos_aspect (float): Width division for vertical DOS
+            color (:obj:`str` or :obj:`tuple`, optional): Line/fill colour in
+                any matplotlib-accepted format
 
         Returns:
             :obj:`matplotlib.pyplot`: The phonon band structure plot.
         """
+
+        if color is None:
+            color = 'C0' # Default to first colour in matplotlib series
 
         if dos_file:
             plt = pretty_subplot(1, 2, width, height, sharex=False, sharey=True, dpi=dpi,
@@ -90,20 +98,26 @@ class SPhononBSPlotter(PhononBSPlotter):
             f = freqs[nd][nb]
 
             # plot band data
-            ax.plot(dists[nd], f, ls='-', c='#3953A4',
+            ax.plot(dists[nd], f, ls='-', c=color,
                     linewidth=band_linewidth)
 
         self._maketicks(ax)
         self._makeplot(ax, plt.gcf(), data, width=width, height=height,
-                       ymin=ymin, ymax=ymax, dos_file=dos_file)
+                       ymin=ymin, ymax=ymax, dos_file=dos_file, color=color)
         plt.tight_layout()
         plt.subplots_adjust(wspace=0)
 
         return plt
 
     def _makeplot(self, ax, fig, data, ymin=None, ymax=None, height=6,
-                  width=6, dos_file=None):
+                  width=6, dos_file=None, color=None):
         """Utility method to tidy phonon band structure diagrams. """
+
+        # Define colours
+        grey = (0.5, 0.5, 0.5)
+        if color is None:
+            color = 'C0' # Default to first colour in matplotlib series
+
         # set x and y limits
         tymax = ymax if ymax else max(flatten(data['frequency']))
         tymin = ymin if ymin else min(flatten(data['frequency']))
@@ -115,10 +129,10 @@ class SPhononBSPlotter(PhononBSPlotter):
 
         ax.set_ylim(ymin, ymax)
         ax.set_xlim(0, data['distances'][-1][-1])
-        ax.axhline(0, color='k')
+        ax.axhline(0, color=grey, linestyle='--')
 
         if dos_file is not None:
-            self._plot_phonon_dos(dos_file, ax=fig.axes[1])
+            self._plot_phonon_dos(dos_file, ax=fig.axes[1], color=color)
         else:
 
             # keep correct aspect ratio square

--- a/sumo/plotting/phonon_bs_plotter.py
+++ b/sumo/plotting/phonon_bs_plotter.py
@@ -70,17 +70,6 @@ class SPhononBSPlotter(PhononBSPlotter):
             :obj:`matplotlib.pyplot`: The phonon band structure plot.
         """
 
-        # if dos_plotter:
-        #     plt = pretty_subplot(1, 2, width, height, sharex=False, dpi=dpi,
-        #                          plt=plt, fonts=fonts,
-        #                          gridspec_kw={'width_ratios': [dos_aspect, 1],
-        #                                       'wspace': 0})
-        #     ax = plt.gcf().axes[0]
-        # else:
-        #     plt = pretty_plot(width, height, dpi=dpi, plt=plt, fonts=fonts)
-        #     ax = plt.gca()
-
-
         if dos_file:
             plt = pretty_subplot(1, 2, width, height, sharex=False, sharey=True, dpi=dpi,
                                  plt=plt, fonts=fonts,


### PR DESCRIPTION
Added a `--dos-file` option to `sumo-phonon-bandplot`, which expects a _total_dos.dat_ from Phonopy.
The colour is hard coded and the aspect ratio is not automatically corrected.
Also, only total dos is plotted rather than partial DOS.

Implemented by @ajjackson and @zccaayo.