### PR TITLE
WIP: BUGFIX: Style files not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ os:
 # command to install dependencies
 install:
   - pip install numpy
-  - travis_wait pip install .
+  - python setup.py sdist
+  - travis_wait pip install dist/sumo-*.tar.gz
 # command to run tests
 script:
   - python -m unittest discover tests

--- a/tests/tests_plotting/test_resources.py
+++ b/tests/tests_plotting/test_resources.py
@@ -1,0 +1,15 @@
+import unittest
+from os.path import isfile
+from pkg_resources import Requirement, resource_filename
+from sumo.plotting import sumo_base_style, sumo_dos_style, sumo_bs_style
+from sumo.plotting import sumo_phonon_style, sumo_optics_style
+
+class StyleSheetsTestCase(unittest.TestCase):
+    def test_style_files(self):
+        """Check style sheets exist"""
+        for style in (sumo_base_style,
+                      sumo_dos_style,
+                      sumo_bs_style,
+                      sumo_phonon_style,
+                      sumo_optics_style):
+            self.assertTrue(isfile(style))


### PR DESCRIPTION
Matplotlib styles not found in non-developer build (Issue #25 ).

- Added test to catch this behaviour
- Travis won't catch it with current config; uses developer-style build

TODO: 
- Change Travis setup to build from dist
- Fix Manifest file to include stylesheets