### PR TITLE
Fix missing floating point on y-axis of optplots.

### DIFF
--- a/sumo/plotting/__init__.py
+++ b/sumo/plotting/__init__.py
@@ -141,7 +141,10 @@ def power_tick(val, pos):
     """Custom power ticker function. """
     if val == 0:
         return r'$\mathregular{0}$'
-    exponent = int(np.log10(val))
+    elif val < 0:
+        exponent = int(np.log10(-val))
+    else:
+        exponent = int(np.log10(val))
     coeff = val / 10**exponent
     return r'$\mathregular{{{:.1f} x 10^{:2d}}}$'.format(coeff, exponent)
 

--- a/sumo/plotting/__init__.py
+++ b/sumo/plotting/__init__.py
@@ -137,7 +137,12 @@ def pretty_subplot(nrows, ncols, width=None, height=None, sharex=True,
     return plt
 
 
-def power_tick(val, pos):
+def curry_power_tick(times_sign=r'\times'):
+    def f(val, pos):
+        return power_tick(val, pos, times_sign=times_sign)
+    return f
+
+def power_tick(val, pos, times_sign=r'\times'):
     """Custom power ticker function. """
     if val == 0:
         return r'$\mathregular{0}$'
@@ -146,8 +151,10 @@ def power_tick(val, pos):
     else:
         exponent = int(np.log10(val))
     coeff = val / 10**exponent
-    return r'$\mathregular{{{:.1f} x 10^{:2d}}}$'.format(coeff, exponent)
 
+    return r'$\mathregular{{{:.1f} {} 10^{:2d}}}$'.format(coeff,
+                                                          times_sign,
+                                                          exponent)
 
 def rgbline(x, y, red, green, blue, alpha=1, linestyles="solid",
             linewidth=2.5):

--- a/sumo/plotting/__init__.py
+++ b/sumo/plotting/__init__.py
@@ -143,7 +143,7 @@ def power_tick(val, pos):
         return r'$\mathregular{0}$'
     exponent = int(np.log10(val))
     coeff = val / 10**exponent
-    return r'$\mathregular{{{:.1g} x 10^{:2d}}}$'.format(coeff, exponent)
+    return r'$\mathregular{{{:.1f} x 10^{:2d}}}$'.format(coeff, exponent)
 
 
 def rgbline(x, y, red, green, blue, alpha=1, linestyles="solid",

--- a/sumo/plotting/optics_plotter.py
+++ b/sumo/plotting/optics_plotter.py
@@ -10,8 +10,9 @@ import numpy as np
 
 from matplotlib import rcParams
 from matplotlib.ticker import MaxNLocator, FuncFormatter, AutoMinorLocator
+from matplotlib.font_manager import findfont, FontProperties
 
-from sumo.plotting import (pretty_plot, power_tick, styled_plot,
+from sumo.plotting import (pretty_plot, curry_power_tick, styled_plot,
                            sumo_base_style, sumo_optics_style)
 
 
@@ -147,7 +148,13 @@ class SOpticsPlotter(object):
         ax.set_xlim(xmin, xmax)
         ax.set_ylim(ymin, ymax)
 
-        ax.yaxis.set_major_formatter(FuncFormatter(power_tick))
+        font = findfont(FontProperties(family=['sans-serif']))
+        if 'Whitney' in font:
+            times_sign = 'x'
+        else:
+            times_sign = r'\times'
+        ax.yaxis.set_major_formatter(
+            FuncFormatter(curry_power_tick(times_sign=times_sign)))
         ax.yaxis.set_major_locator(MaxNLocator(5))
         ax.xaxis.set_major_locator(MaxNLocator(3))
         ax.yaxis.set_minor_locator(AutoMinorLocator(2))

--- a/sumo/plotting/sumo_base.mplstyle
+++ b/sumo/plotting/sumo_base.mplstyle
@@ -4,7 +4,7 @@ figure.dpi: 400
 axes.prop_cycle: cycler('color', ['f0a3ff', '0075dc', '993f00', '4c005c', '426600', 'ff0010', '9dcc00', 'c20088', '003380', 'ffa405', 'ffff00', 'ff5005', '5ef1f2', '740aff', '990000', '00998f', '005c31', '2bce48', 'ffcc99', '94ffb5', '8f7c00', '6fa8bb', '808080'])
 
 font.family : sans-serif
-font.sans-serif : Whitney Book Extended, Whitney Book, Helvetica, Liberation Sans, Andale Sans, Arial
+font.sans-serif : Whitney Book Extended, Catamaran, Helvetica, Liberation Sans, Andale Sans, Arial
 
 font.size : 22
 


### PR DESCRIPTION
In sumo-optplot default behavior rounded y-axis to an apparent float value. 
![image](https://user-images.githubusercontent.com/27951554/48714298-584bf080-ec0a-11e8-92dd-871cd6984028.png).

Format string changed from 'g' to 'f' to allow floating point. 
