### PR TITLE
ENH: Enable secret points on band structure path

### DIFF
--- a/sumo/cli/kgen.py
+++ b/sumo/cli/kgen.py
@@ -100,7 +100,8 @@ def kgen(filename='POSCAR', directory=None, make_folders=False, symprec=0.01,
 
             combined with the above example for ``kpt_list`` would indicate the
             path: Gamma -> Z | X -> M. If no labels are provided, letters from
-            A -> Z will be used instead.
+            A -> Z will be used instead. If a label begins with '@' it will be
+            concealed when plotting with sumo-bandplot.
     """
     poscar = Poscar.from_file(filename)
     kpath, kpoints, labels = get_path_data(poscar.structure, mode=mode,

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -533,6 +533,22 @@ class SBSPlotter(BSPlotter):
             unique_d.append(temp_ticks[0][0])
             unique_l.append(temp_ticks[0][1])
             for i in range(1, len(temp_ticks)):
+                # Hide labels marked with @
+                if '@' in temp_ticks[i][1]:
+                    # If a branch connection, check all parts of label
+                    if r'$\mid$' in temp_ticks[i][1]:
+                        label_components = temp_ticks[i][1].split(r'$\mid$')
+                        good_labels = [l for l in label_components
+                                       if l[0] != '@']
+                        if len(good_labels) == 0:
+                            continue
+                        else:
+                            temp_ticks[i] = (temp_ticks[i][0],
+                                         r'$\mid$'.join(good_labels))
+                    # If a single label, check first character
+                    elif temp_ticks[i][1][0] == '@':
+                        continue
+
                 if unique_l[-1] != temp_ticks[i][1]:
                     unique_d.append(temp_ticks[i][0])
                     unique_l.append(temp_ticks[i][1])


### PR DESCRIPTION
Allows a special point to be left unmarked on electronic bandplot
by using a label beginning with an '@' character.

This is intended to provide a workaround for a specific problem:
specifying custom k-point paths where some high-symmetry points have
multiple definitions.

For example, in a zincblende cell the U and K points are equivalent
but have different standard coordinates to represent the direction
they are typically approached from. In order to present a band
structure in which the U|K point is simply labelled 'K', one can
set up an appropriate KPOINTS file with

  sumo-kgen --labels "\Gamma,X,K|@U,\Gamma" --kpoints "0 0 0, 0.5 0.0 0.5, 0.625 0.25 0.625 | 0.375 0.375 0.75, 0 0 0"

However, hidden points do not have to be located at discontinuities
and the labels of other special points might be hidden in the same way
in order to create a cleaner plot while exploring specific tours
through the Brillouin zone.