### PR TITLE
Enable repeat labels on band structure, made unique internally with trailing @

### DIFF
--- a/tests/tests_plotting/test_band_plotter.py
+++ b/tests/tests_plotting/test_band_plotter.py
@@ -1,0 +1,45 @@
+import unittest
+
+from sumo.plotting.bs_plotter import SBSPlotter
+
+class SanitiseLabelTestCase(unittest.TestCase):
+    def test_sanitise_label(self):
+        for label_in, label_out in (('X', 'X'),
+                                    ('X 1', 'X 1'),
+                                    ('X @', 'X '),
+                                    ('X@', 'X'),
+                                    ('X@@@', 'X'),
+                                    ('HEX', 'HEX'),
+                                    ('HE@X', 'HE@X'),
+                                    ('HE@X 1', 'HE@X 1'),
+                                    ('@', None),
+                                    ('@X', None),
+                                    ('@HEX', None)):
+
+            self.assertEqual(SBSPlotter._sanitise_label(label_in), label_out)
+
+    def test_sanitise_label_group(self):
+        for label_in, label_out in (('X', 'X'),
+                                    ('X 1', 'X 1'),
+                                    ('X @', 'X '),
+                                    ('X@', 'X'),
+                                    ('X@@@', 'X'),
+                                    ('HEX', 'HEX'),
+                                    ('HE@X', 'HE@X'),
+                                    ('HE@X 1', 'HE@X 1'),
+                                    ('@', None),
+                                    ('@X', None),
+                                    ('@HEX', None),
+                                    (r'X$\mid$Y', r'X$\mid$Y'),
+                                    (r'X$\mid$Y$\mid$Z', r'X$\mid$Y$\mid$Z'),
+                                    (r'@X$\mid$Y$\mid$Z', r'Y$\mid$Z'),
+                                    (r'X$\mid$@Y$\mid$Z', r'X$\mid$Z'),
+                                    (r'X$\mid$@Z', r'X'),
+                                    (r'X@$\mid$Y', r'X$\mid$Y'),
+                                    (r'X@$\mid$Y@@', r'X$\mid$Y'),
+                                    (r'@X@$\mid$Y@', r'Y'),
+                                    (r'X@$\mid$@Y', r'X'),
+                                    (r'@X@$\mid$@Y', None)):
+
+            self.assertEqual(SBSPlotter._sanitise_label_group(label_in),
+                             label_out)


### PR DESCRIPTION
Another "secret labels" feature to aid with use of custom k-point paths. High-symmetry points are handled in Pymatgen and Sumo as a dictionary of labels and positions. This means that it is prohibited to re-use the same label for a different k-point, even if that position is actually symmetry-equivalent or a periodic image in reciprocal space.

There are arguments for and against using such band structures, but here we provide a workaround for those who wish to re-use labels for non-equivalent points. By appending an '@' symbol to the label in
KPOINTS or syml.ext (i.e. 'X' becomes 'X@'), a new special point is identified which will also display as 'X' in the plotted band structure. What if you need another one? Just add more @ signs, the code uses regular expressions to look for a block of @ signs at the end of the label.