### PR TITLE
Primitive cells in phonon-bandplot

### DIFF
--- a/sumo/phonon/phonopy.py
+++ b/sumo/phonon/phonopy.py
@@ -87,7 +87,9 @@ def load_phonopy(filename, structure, dim, symprec=0.01, primitive_matrix=None,
 
     if born:
         # load born parameters from a file
-        nac_params = file_IO.parse_BORN(unitcell, filename=born)
+        nac_params = file_IO.parse_BORN(unitcell,
+                                        symprec=symprec,
+                                        filename=born)
 
         # set the nac unit conversion factor manual,  specific to VASP
         nac_params['factor'] = Hartree * Bohr

--- a/sumo/phonon/phonopy.py
+++ b/sumo/phonon/phonopy.py
@@ -87,7 +87,7 @@ def load_phonopy(filename, structure, dim, symprec=0.01, primitive_matrix=None,
 
     if born:
         # load born parameters from a file
-        nac_params = file_IO.parse_BORN(unitcell,
+        nac_params = file_IO.parse_BORN(phonon._primitive,
                                         symprec=symprec,
                                         filename=born)
 

--- a/sumo/phonon/phonopy.py
+++ b/sumo/phonon/phonopy.py
@@ -28,10 +28,11 @@ def load_phonopy(filename, structure, dim, symprec=0.01, primitive_matrix=None,
         dim (list): The supercell size, as a :obj:`list` of :obj:`float`.
         symprec (:obj:`float`, optional): The tolerance for determining the
             crystal symmetry.
-        primitive_matrix (:obj:`list`, optional): The transformation matrix
-            from the conventional to primitive cell. Only required when the
-            conventional cell was used as the starting structure. Should be
-            provided as a 3x3 :obj:`list` of :obj:`float`.
+        primitive_matrix (:obj:`list` or :obj:`str`, optional): The
+            transformation matrix from the conventional to primitive cell. Only
+            required when the conventional cell was used as the starting
+            structure. Should be provided as a 3x3 :obj:`list` of :obj:`float`.
+            Alternatively the str 'auto' may be provided.
         factor (:obj:`float`, optional): The conversion factor for phonon
             frequency. Defaults to :obj:`phonopy.units.VaspToTHz`.
         symmetrise (:obj:`bool`, optional): Symmetrise the force constants.


### PR DESCRIPTION
Bugfix for #57 

The BORN file should contain a primitive cell, but Sumo was passing the full unit cell to Phonopy, leading to a mismatch in atom count (and, presumably, in coordinates...). The fix accesses an internal Phonopy attribute, which isn't ideal but seems the best option for internal consistency and minimal user input.

While fixing this, I also added support for the new(ish) Phonopy option `--primitive-axis=auto`, which may be accessed with `sumo-phonon-bandplot --primitive-auto`. A very welcome feature, this should make working with primitive cells less tedious.