### PR TITLE
Restrict Pymatgen version for Python 3.5 installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,15 +33,20 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.5',                 
         'Topic :: Scientific/Engineering :: Chemistry',
         'Topic :: Scientific/Engineering :: Physics'
         ],
     keywords='chemistry pymatgen dft vasp dos band',
     test_suite='setup.load_test_suite',
     packages=find_packages(),
-    install_requires=['spglib', 'numpy', 'scipy', 'pymatgen>=2017.12.30',
+    install_requires=['spglib', 'numpy', 'scipy',
                       'h5py', 'phonopy>=2.1.3', 'matplotlib', 'seekpath'],
-    extras_require={'docs': ['sphinx', 'sphinx-argparse']},
+    extras_require={'docs': ['sphinx', 'sphinx-argparse'],
+                    ':python_version=="3.5"': [
+                        'pymatgen >=2016.12.30, <=2019.6.20'],
+                    ':python_version>="3.6"': ['pymatgen>=2017.12.30']
+                        },
     package_data={'sumo': ['symmetry/bradcrack.json',
                            'plotting/orbital_colours.conf',
                            'plotting/sumo_base.mplstyle',


### PR DESCRIPTION
This should solve #62 by restricting the range of installed Pymatgen versions when installing Sumo under 3.5. We should do at least one point-release with this in place before dropping 3.5 support ourselves so that 3.5 users have a known working Sumo installer. We will however need to drop 3.5 when we use any new Pymatgen features.

Once this is in master I suggest that other pull requests rebase and force-push in order to get their CI working without adding a lot of merges to the history.