### PR TITLE
Phonon bandplot: JSON dumping/loading, overlaying plots

### DIFF
--- a/sumo/cli/phonon_bandplot.py
+++ b/sumo/cli/phonon_bandplot.py
@@ -199,7 +199,8 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
     plotter = SPhononBSPlotter(bs)
     plt = plotter.get_plot(units=units, ymin=ymin, ymax=ymax, height=height,
                            width=width, plt=plt, fonts=fonts, dos=dos,
-                           from_json=from_json, legend=legend)
+                           from_json=from_json, legend=legend,
+                           style=style, no_base_style=no_base_style)
 
     if save_files:
         basename = 'phonon_band.{}'.format(image_format)

--- a/sumo/cli/phonon_bandplot.py
+++ b/sumo/cli/phonon_bandplot.py
@@ -7,12 +7,9 @@ A script to plot phonon band structure diagrams.
 
 TODO:
  * automatically plot dos if present in band.yaml
- * primitive axis determination (try symmetrise->spglib->PA then apply
-   transform on original cell and see if it works.
  * make band structure from vasprun displacement/DFPT files
  * deal with magnetic moments
- * Read FORCE_CONSANTS or force_constants.hdf5
- * change frequency unit
+ * Read force_constants.hdf5
  * read settings from phonopy config file
  * prefix file names
 """

--- a/sumo/cli/phonon_bandplot.py
+++ b/sumo/cli/phonon_bandplot.py
@@ -42,7 +42,6 @@ from sumo.phonon.phonopy import load_phonopy
 from sumo.symmetry.kpoints import get_path_data
 from sumo.plotting.phonon_bs_plotter import SPhononBSPlotter
 
-
 __author__ = "Alex Ganose"
 __version__ = "1.0"
 __maintainer__ = "Alex Ganose"
@@ -164,9 +163,9 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
     if filename is None:
         if from_json is None:
             filename = 'FORCE_SETS'
-            bs = _bs_from_filename(filename, poscar, dim, symprec, spg,
-                                   kpt_list, labels, primitive_axis, units,
-                                   born, mode, eigenvectors)
+            bs, phonon = _bs_from_filename(filename, poscar, dim, symprec, spg,
+                                           kpt_list, labels, primitive_axis,
+                                           units, born, mode, eigenvectors)
 
         else:
             logging.info("No input data, using file {} "
@@ -175,9 +174,9 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
                 bs = PhononBandStructureSymmLine.from_dict(json.load(f))
             from_json = from_json[1:]
     else:
-        bs = _bs_from_filename(filename, poscar, dim, symprec, spg, kpt_list,
-                               labels, primitive_axis, units, born, mode,
-                               eigenvectors)
+        bs, phonon = _bs_from_filename(filename, poscar, dim, symprec, spg,
+                                       kpt_list, labels, primitive_axis, units,
+                                       born, mode, eigenvectors)
 
     if to_json is not None:
         logging.info("Writing symmetry lines to {}".format(to_json))
@@ -201,7 +200,7 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
                            width=width, plt=plt, fonts=fonts, dos=dos,
                            style=style, no_base_style=no_base_style,
                            from_json=from_json, legend=legend)
-    
+
     if save_files:
         basename = 'phonon_band.{}'.format(image_format)
         filename = '{}_{}'.format(prefix, basename) if prefix else basename
@@ -323,7 +322,7 @@ def _bs_from_filename(filename, poscar, dim, symprec, spg, kpt_list, labels,
 
     bs = get_ph_bs_symm_line(yaml_file, has_nac=False,
                              labels_dict=kpath.kpoints)
-    return bs
+    return bs, phonon
 
 
 def _get_parser():

--- a/sumo/cli/phonon_bandplot.py
+++ b/sumo/cli/phonon_bandplot.py
@@ -17,17 +17,17 @@ TODO:
  * prefix file names
 """
 
+import argparse
+import json
 import os
 from os.path import isfile
 import sys
 import logging
-import argparse
-import numpy as np
 
+import numpy as np
 import warnings
 warnings.filterwarnings("ignore", category=FutureWarning,
                         module="h5py")
-
 import matplotlib as mpl
 mpl.use('Agg')
 from matplotlib import rcParams
@@ -36,6 +36,7 @@ from phonopy.units import VaspToTHz, VaspToEv, VaspToCm
 
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.phonopy import get_ph_bs_symm_line
+from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 
 from sumo.phonon.phonopy import load_phonopy
 from sumo.symmetry.kpoints import get_path_data
@@ -56,7 +57,8 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
                     eigenvectors=False, labels=None, height=6., width=6.,
                     style=None, no_base_style=False,
                     ymin=None, ymax=None, image_format='pdf', dpi=400,
-                    plt=None, fonts=None, dos=None):
+                    plt=None, fonts=None, dos=None,
+                    to_json=None, from_json=None):
     """A script to plot phonon band structure diagrams.
 
     Args:
@@ -69,6 +71,7 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
             current directory.
         prefix (:obj:`str`, optional): Prefix for file names.
         directory (:obj:`str`, optional): The directory in which to save files.
+        dim (:obj:`list`, optional): supercell matrix
         born (:obj:`str`, optional): Path to file containing Born effective
             charges. Should be in the same format as the file produced by the
             ``phonopy-vasp-born`` script provided by phonopy.
@@ -142,81 +145,40 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
         fonts (:obj:`list`, optional): Fonts to use in the plot. Can be a
             a single font, specified as a :obj:`str`, or several fonts,
             specified as a :obj:`list` of :obj:`str`.
+        to_json (:obj:`str`, optional): JSON file to dump the Pymatgen band
+            path object.
+        from_json (:obj:`list` or :obj:`str`): (List of) JSON bandpath data
+            filename(s) to import and overlay.
 
     Returns:
         A matplotlib pyplot object.
     """
-    if '.yaml' in filename:
-        yaml_file = filename
-    elif ('FORCE_SETS' == filename or 'FORCE_CONSTANTS' == filename or
-            '.hdf5' in filename):
-        try:
-            poscar = poscar if poscar else 'POSCAR'
-            poscar = Poscar.from_file(poscar)
-        except IOError:
-            msg = "Cannot find POSCAR file, cannot generate symmetry path."
-            logging.error("\n {}".format(msg))
-            sys.exit()
-
-        if not dim:
-            logging.info("Supercell size (--dim option) not provided.\n"
-                         "Attempting to guess supercell dimensions.\n")
-            try:
-                sposcar = Poscar.from_file("SPOSCAR")
-            except IOError:
-                msg = "Could not determine supercell size (use --dim flag)."
-                logging.error("\n {}".format(msg))
-                sys.exit()
-
-            dim = (sposcar.structure.lattice.matrix *
-                   poscar.structure.lattice.inv_matrix)
-
-            # round due to numerical noise error
-            dim = np.around(dim, 5)
-
-        elif len(dim) == 9:
-            dim = np.array(dim).reshape(3, 3)
-
-        elif np.array(dim).shape != (3, 3):
-            dim = np.diagflat(dim)
-
-        logging.info("Using supercell with dimensions:")
-        logging.info('\t' + str(dim).replace('\n', '\n\t')+'\n')
-
-        factors = {'ev': VaspToEv, 'thz': VaspToTHz, 'mev': VaspToEv * 1000,
-                   'cm-1': VaspToCm}
-
-        phonon = load_phonopy(filename, poscar.structure, dim, symprec=symprec,
-                              primitive_matrix=primitive_axis,
-                              factor=factors[units.lower()],
-                              symmetrise=True, born=born,
-                              write_fc=False)
-
-        # calculate band structure
-        kpath, kpoints, labels = get_path_data(poscar.structure, mode=mode,
-                                               symprec=symprec, spg=spg,
-                                               kpt_list=kpt_list,
-                                               labels=labels, phonopy=True)
-
-        # todo: calculate dos and plot also
-        # phonon.set_mesh(mesh, is_gamma_center=False, is_eigenvectors=True,
-        #                 is_mesh_symmetry=False)
-        # phonon.set_partial_DOS()
-
-        phonon.set_band_structure(
-            kpoints, is_eigenvectors=eigenvectors, labels=labels)
-        yaml_file = 'sumo_band.yaml'
-        phonon._band_structure.write_yaml(filename=yaml_file)
-
-    else:
-        msg = "Do not recognise file type of {}".format(filename)
-        logging.error("\n {}".format(msg))
-        sys.exit()
-
     save_files = False if plt else True  # don't save if pyplot object provided
+    if isinstance(from_json, str):
+        from_json = [from_json]
 
-    bs = get_ph_bs_symm_line(yaml_file, has_nac=False,
-                             labels_dict=kpath.kpoints)
+    if filename is None:
+        if from_json is None:
+            filename = 'FORCE_SETS'
+            bs = _bs_from_filename(filename, poscar, dim, symprec, spg,
+                                   kpt_list, labels, primitive_axis, units,
+                                   born, mode, eigenvectors)
+
+        else:
+            logging.info("No input data, using file {} "
+                         "to construct plot".format(from_json[0]))
+            with open(from_json[0], 'r') as f:
+                bs = PhononBandStructureSymmLine.from_dict(json.load(f))
+            from_json = from_json[1:]
+    else:
+        bs = _bs_from_filename(filename, poscar, dim, symprec, spg, kpt_list,
+                               labels, primitive_axis, units, born, mode,
+                               eigenvectors)
+
+    if to_json is not None:
+        logging.info("Writing symmetry lines to {}".format(to_json))
+        with open(to_json, 'wt') as f:
+            f.write(bs.to_json())
 
     # Replace dos filename with data array
     if dos is not None:
@@ -232,7 +194,8 @@ def phonon_bandplot(filename, poscar=None, prefix=None, directory=None,
 
     plotter = SPhononBSPlotter(bs)
     plt = plotter.get_plot(units=units, ymin=ymin, ymax=ymax, height=height,
-                           width=width, plt=plt, fonts=fonts, dos=dos)
+                           width=width, plt=plt, fonts=fonts, dos=dos,
+                           from_json=from_json)
 
     if save_files:
         basename = 'phonon_band.{}'.format(image_format)
@@ -280,6 +243,84 @@ def save_data_files(bs, prefix=None, directory=None):
     return filename
 
 
+def _bs_from_filename(filename, poscar, dim, symprec, spg, kpt_list, labels,
+                      primitive_axis, units, born, mode, eigenvectors):
+    """Analyse input files to create band structure"""
+
+    if '.yaml' in filename:
+        yaml_file = filename
+
+    elif ('FORCE_SETS' == filename
+          or 'FORCE_CONSTANTS' == filename
+          or '.hdf5' in filename):
+        try:
+            poscar = poscar if poscar else 'POSCAR'
+            poscar = Poscar.from_file(poscar)
+        except IOError:
+            msg = "Cannot find POSCAR file, cannot generate symmetry path."
+            logging.error("\n {}".format(msg))
+            sys.exit()
+
+        if not dim:
+            logging.info("Supercell size (--dim option) not provided.\n"
+                         "Attempting to guess supercell dimensions.\n")
+            try:
+                sposcar = Poscar.from_file("SPOSCAR")
+            except IOError:
+                msg = "Could not determine supercell size (use --dim flag)."
+                logging.error("\n {}".format(msg))
+                sys.exit()
+
+            dim = (sposcar.structure.lattice.matrix *
+                   poscar.structure.lattice.inv_matrix)
+
+            # round due to numerical noise error
+            dim = np.around(dim, 5)
+
+        elif len(dim) == 9:
+            dim = np.array(dim).reshape(3, 3)
+
+        elif np.array(dim).shape != (3, 3):
+            dim = np.diagflat(dim)
+
+        logging.info("Using supercell with dimensions:")
+        logging.info('\t' + str(dim).replace('\n', '\n\t')+'\n')
+
+        factors = {'ev': VaspToEv, 'thz': VaspToTHz, 'mev': VaspToEv * 1000,
+                   'cm-1': VaspToCm}
+
+        phonon = load_phonopy(filename, poscar.structure, dim, symprec=symprec,
+                              primitive_matrix=primitive_axis,
+                              factor=factors[units.lower()],
+                              symmetrise=True, born=born,
+                              write_fc=False)
+
+    else:
+        msg = "Do not recognise file type of {}".format(filename)
+        logging.error("\n {}".format(msg))
+        sys.exit()
+
+    # calculate band structure
+    kpath, kpoints, labels = get_path_data(poscar.structure, mode=mode,
+                                           symprec=symprec, spg=spg,
+                                           kpt_list=kpt_list,
+                                           labels=labels, phonopy=True)
+
+    # todo: calculate dos and plot also
+    # phonon.set_mesh(mesh, is_gamma_center=False, is_eigenvectors=True,
+    #                 is_mesh_symmetry=False)
+    # phonon.set_partial_DOS()
+
+    phonon.set_band_structure(
+        kpoints, is_eigenvectors=eigenvectors, labels=labels)
+    yaml_file = 'sumo_band.yaml'
+    phonon._band_structure.write_yaml(filename=yaml_file)
+
+    bs = get_ph_bs_symm_line(yaml_file, has_nac=False,
+                             labels_dict=kpath.kpoints)
+    return bs
+
+
 def _get_parser():
     parser = argparse.ArgumentParser(description="""
     phonon-bandplot is a script to produce publication ready phonon band
@@ -289,7 +330,7 @@ def _get_parser():
     Version: {}
     Last updated: {}""".format(__author__, __version__, __date__))
 
-    parser.add_argument('-f', '--filename', default='FORCE_SETS', metavar='F',
+    parser.add_argument('-f', '--filename', default=None, metavar='F',
                         help="FORCE_SETS, FORCE_CONSTANTS or band.yaml file")
     parser.add_argument('-p', '--prefix', metavar='P',
                         help='prefix for the files generated.')
@@ -363,6 +404,11 @@ def _get_parser():
     parser.add_argument('--dos', nargs='?', type=str,
                         default=None, const=True,
                         help='Phonopy .dat file for phonon DOS')
+    parser.add_argument('--to-json', type=str, default=None,
+                        help='Output JSON file for band data')
+    parser.add_argument('--from-json', type=str, nargs='+', default=None,
+                        dest='from_json',
+                        help='Overlay band data from JSON files')
     return parser
 
 
@@ -421,7 +467,8 @@ def main():
                     ymax=args.ymax, image_format=args.image_format,
                     style=args.style, no_base_style=args.no_base_style,
                     dpi=args.dpi, fonts=args.font,
-                    eigenvectors=args.eigenvectors, dos=args.dos)
+                    eigenvectors=args.eigenvectors, dos=args.dos,
+                    to_json=args.to_json, from_json=args.from_json)
 
 
 if __name__ == "__main__":

--- a/sumo/phonon/phonopy.py
+++ b/sumo/phonon/phonopy.py
@@ -53,12 +53,12 @@ def load_phonopy(filename, structure, dim, symprec=0.01, primitive_matrix=None,
     phonon = Phonopy(unitcell, dim, primitive_matrix=primitive_matrix,
                      factor=factor, symprec=symprec)
 
-    if 'FORCE_CONSTANTS' == filename or '.hdf5' in filename:
+    if 'FORCE_CONSTANTS' in filename or '.hdf5' in filename:
         # if force constants exist, use these to avoid recalculating them
         if '.hdf5' in filename:
             fc = file_IO.read_force_constants_hdf5(filename)
 
-        elif 'FORCE_CONSTANTS' == filename:
+        elif 'FORCE_CONSTANTS' in filename:
             fc = file_IO.parse_FORCE_CONSTANTS(filename=filename)
 
         if fc.shape[0] != num_satom:
@@ -70,9 +70,9 @@ def load_phonopy(filename, structure, dim, symprec=0.01, primitive_matrix=None,
 
         phonon.set_force_constants(fc)
 
-    elif 'FORCE_SETS' == filename:
+    elif 'FORCE_SETS' in filename:
         # load the force sets from file and calculate force constants
-        fs = file_IO.parse_FORCE_SETS()
+        fs = file_IO.parse_FORCE_SETS(filename=filename)
 
         if fs['natom'] != num_satom:
             msg = ("\nNumber of atoms in supercell is not consistent with the "

--- a/sumo/plotting/phonon_bs_plotter.py
+++ b/sumo/plotting/phonon_bs_plotter.py
@@ -145,8 +145,13 @@ class SPhononBSPlotter(PhononBSPlotter):
 
         for i, bs_json in enumerate(from_json):
             with open(bs_json, 'rt') as f:
-                bs = PhononBandStructureSymmLine.from_dict(json.load(f))
-                bs.lattice_rec = self._bs.lattice_rec
+                json_data = json.load(f)
+                json_data['lattice_rec'] = json.loads(
+                    self._bs.lattice_rec.to_json())
+                bs = PhononBandStructureSymmLine.from_dict(json_data)
+
+                # bs.lattice_rec = self._bs.lattice_rec
+                # raise Exception(bs.qpoints)
             json_plotter = PhononBSPlotter(bs)
             json_data = json_plotter.bs_plot_data()
             if json_plotter._nb_bands != self._nb_bands:

--- a/sumo/plotting/phonon_bs_plotter.py
+++ b/sumo/plotting/phonon_bs_plotter.py
@@ -62,7 +62,7 @@ class SPhononBSPlotter(PhononBSPlotter):
     def get_plot(self, units='THz', ymin=None, ymax=None, width=None,
                  height=None, dpi=None, plt=None, fonts=None, dos=None,
                  dos_aspect=3, color=None, style=None, no_base_style=False,
-                 from_json=None):
+                 from_json=None, legend=None):
         """Get a :obj:`matplotlib.pyplot` object of the phonon band structure.
 
         Args:
@@ -103,6 +103,16 @@ class SPhononBSPlotter(PhononBSPlotter):
         if from_json is None:
             from_json = []
 
+        if legend is None:
+            legend = [''] * (len(from_json) + 1)
+        else:
+            if len(legend) == 1 + len(from_json):
+                pass
+            elif len(legend) == len(from_json):
+                legend = [''] + list(legend)
+            else:
+                raise ValueError('Inappropriate number of legend entries')
+
         if color is None:
             color = 'C0'  # Default to first colour in matplotlib series
 
@@ -127,7 +137,8 @@ class SPhononBSPlotter(PhononBSPlotter):
                 f = freqs[nd][nb]
 
                 # plot band data
-                ax.plot(dists[nd], f, ls='-', c=color, zorder=zorder)
+                ax.plot(dists[nd], f, ls='-', c=color,
+                        zorder=zorder)
 
         data = self.bs_plot_data()
         _plot_lines(data, ax, color=color)
@@ -141,10 +152,15 @@ class SPhononBSPlotter(PhononBSPlotter):
             if json_plotter._nb_bands != self._nb_bands:
                 raise Exception('Number of bands in {} does not match '
                                 'main plot'.format(bs_json))
-            alpha = (i + 1)/(len(from_json) + 1)
             _plot_lines(json_data, ax,
                         color='C{}'.format(i + 1),
                         zorder=0.5)
+
+        if any(legend):  # Don't show legend if all entries are empty string
+            from matplotlib.lines import Line2D
+            ax.legend([Line2D([0], [0], color='C{}'.format(i))
+                       for i in range(len(legend))],
+                       legend)
 
         self._maketicks(ax, units=units)
         self._makeplot(ax, plt.gcf(), data, width=width, height=height,

--- a/sumo/plotting/sumo_phonon.mplstyle
+++ b/sumo/plotting/sumo_phonon.mplstyle
@@ -1,1 +1,2 @@
-axes.prop_cycle : cycler('color', ['2ca02c'])
+# Thank you http://colorbrewer2.org/
+axes.prop_cycle : cycler('color', ['006d2c', '2ca25f', '66c2a4', 'b2e2e2'])

--- a/tests/tests_phonon/test_phonopy.py
+++ b/tests/tests_phonon/test_phonopy.py
@@ -1,0 +1,35 @@
+import unittest
+from os.path import join as path_join
+from pkg_resources import resource_filename
+
+import numpy as np
+from phonopy import Phonopy
+from pymatgen.io.vasp.inputs import Poscar
+import sumo.phonon.phonopy
+
+class PhonopyTestCase(unittest.TestCase):
+    def setUp(self):
+        self.phonon_data = resource_filename(__name__, path_join('..',
+                                                                 'data',
+                                                                 'RbSnI6',
+                                                                 'phonopy',
+                                                                 'FORCE_SETS'))
+        poscar_path = resource_filename(__name__, path_join('..',
+                                                            'data',
+                                                            'RbSnI6',
+                                                            'phonopy',
+                                                            'POSCAR'))
+        phonon_poscar = Poscar.from_file(poscar_path)
+        self.phonon_structure = phonon_poscar.structure
+
+    def test_phonopy_load(self):
+        phonopy_obj = sumo.phonon.phonopy.load_phonopy(self.phonon_data,
+                                                       self.phonon_structure,
+                                                       np.diag([3, 3, 2]))
+        self.assertIsInstance(phonopy_obj, Phonopy)
+
+        self.assertEquals(phonopy_obj.force_constants.shape, (324, 324, 3, 3))
+        self.assertAlmostEqual(phonopy_obj.force_constants.trace().trace(),
+                               2654.3381334806545)
+        self.assertAlmostEqual(phonopy_obj.force_constants[4, 3, 2, 1],
+                               0.000552387416908992)


### PR DESCRIPTION
Here's an attempt at #65 

So far we can dump a JSON of the Pymatgen object with `--to-json filename.json`, and select multiple of them to add to the plotting output with `--from-json bands-1.json bands-2.json ...`, . If no FORCE_SETS etc. is chosen but --from-json is set, then instead of looking for FORCE_SETS it will just plot the series of JSON files.

I tweaked the style file so the default green is a little darker and we get a green -> pale-blue sequence of up to four colours.

![phonon_band](https://user-images.githubusercontent.com/2511383/61541518-be0da800-aa37-11e9-9c60-708b45110e5f.png)

Todo:

- `--style` seems to be broken?
- Check the x-axis scaling is working correctly with some qha data. (If anyone has some lying around that would be great.)
- `--labels`