### PR TITLE
Spin-Polarisation Selection Option 

### DIFF
--- a/sumo/cli/bandplot.py
+++ b/sumo/cli/bandplot.py
@@ -165,8 +165,9 @@ def bandplot(filenames=None, code='vasp', prefix=None, directory=None,
 
             If ``atoms`` is not set or set to ``None`` then all atomic sites
             for all elements will be considered.
-        spin (:obj:`str`, optional): Plot a spin-polarised band structure,
-            "up" for spin up only, "down" for spin down only. Defaults to ``None``.
+        spin (:obj:`str`, optional): Plot only one spin channel from a
+            spin-polarised calculation; "up" for spin up only, "down" for
+            spin down only. Defaults to ``None``.
         total_only (:obj:`bool`, optional): Only extract the total density of
             states. Defaults to ``False``.
         plot_total (:obj:`bool`, optional): Plot the total density of states.
@@ -480,7 +481,8 @@ def _get_parser():
     parser.add_argument('--atoms', type=_atoms, metavar='A',
                         help=('atoms to include (e.g. "O.1.2.3,Ru.1.2.3")'))
     parser.add_argument('--spin', type=str, default=None,
-                        help=('select spin for spin-polarised BS (options: up, down)'))
+                        help=('select only one spin channel for a spin-polarised '
+                              'calculation (options: up, down)'))
     parser.add_argument('--scissor', type=float, default=None, dest='scissor',
                         help='apply scissor operator')
     parser.add_argument('--total-only', action='store_true', dest='total_only',

--- a/sumo/cli/bandplot.py
+++ b/sumo/cli/bandplot.py
@@ -51,7 +51,7 @@ def bandplot(filenames=None, code='vasp', prefix=None, directory=None,
              interpolate_factor=4, circle_size=150, dos_file=None,
              cart_coords=False, scissor=None,
              ylabel='Energy (eV)', dos_label=None,
-             elements=None, lm_orbitals=None, atoms=None,
+             elements=None, lm_orbitals=None, atoms=None, spin=None,
              total_only=False, plot_total=True, legend_cutoff=3, gaussian=None,
              height=None, width=None, ymin=-6., ymax=6., colours=None,
              yscale=1, style=None, no_base_style=False,
@@ -165,6 +165,8 @@ def bandplot(filenames=None, code='vasp', prefix=None, directory=None,
 
             If ``atoms`` is not set or set to ``None`` then all atomic sites
             for all elements will be considered.
+        spin (:obj:`str`, optional): Plot a spin-polarised band structure,
+            "up" for spin up only, "down" for spin down only. Defaults to ``None``.
         total_only (:obj:`bool`, optional): Only extract the total density of
             states. Defaults to ``False``.
         plot_total (:obj:`bool`, optional): Plot the total density of states.
@@ -299,14 +301,14 @@ def bandplot(filenames=None, code='vasp', prefix=None, directory=None,
             width=width, vbm_cbm_marker=vbm_cbm_marker, ylabel=ylabel,
             plt=plt, dos_plotter=dos_plotter, dos_options=dos_opts,
             dos_label=dos_label, fonts=fonts, style=style,
-            no_base_style=no_base_style)
+            no_base_style=no_base_style, spin=spin)
     else:
         plt = plotter.get_plot(
             zero_to_efermi=True, ymin=ymin, ymax=ymax, height=height,
             width=width, vbm_cbm_marker=vbm_cbm_marker, ylabel=ylabel,
             plt=plt, dos_plotter=dos_plotter, dos_options=dos_opts,
             dos_label=dos_label, fonts=fonts, style=style,
-            no_base_style=no_base_style)
+            no_base_style=no_base_style, spin=spin)
 
     if save_files:
         basename = 'band.{}'.format(image_format)
@@ -477,6 +479,8 @@ def _get_parser():
                               'contributions (e.g. "Ru.d")'))
     parser.add_argument('--atoms', type=_atoms, metavar='A',
                         help=('atoms to include (e.g. "O.1.2.3,Ru.1.2.3")'))
+    parser.add_argument('--spin', type=str, default=None,
+                        help=('select spin for spin-polarised BS (options: up, down)'))
     parser.add_argument('--scissor', type=float, default=None, dest='scissor',
                         help='apply scissor operator')
     parser.add_argument('--total-only', action='store_true', dest='total_only',
@@ -546,7 +550,7 @@ def main():
              circle_size=args.circle_size, yscale=args.scale,
              ylabel=args.ylabel, dos_label=args.dos_label,
              dos_file=args.dos, elements=args.elements,
-             lm_orbitals=args.orbitals, atoms=args.atoms,
+             lm_orbitals=args.orbitals, atoms=args.atoms, spin=args.spin,
              total_only=args.total_only, plot_total=args.total,
              legend_cutoff=args.legend_cutoff, gaussian=args.gaussian,
              height=args.height, width=args.width, ymin=args.ymin,

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -40,11 +40,11 @@ __date__ = "April 9, 2018"
 
 
 def dosplot(filename=None, code='vasp', prefix=None, directory=None,
-            elements=None, lm_orbitals=None, atoms=None, subplot=False,
-            shift=True, total_only=False, plot_total=True, legend_on=True,
-            legend_frame_on=False, legend_cutoff=3., gaussian=None, height=6.,
-            width=8., xmin=-6., xmax=6., num_columns=2, colours=None, yscale=1,
-            xlabel='Energy (eV)', ylabel='Arb. units',
+            elements=None, lm_orbitals=None, atoms=None, spin=None,
+            subplot=False, shift=True, total_only=False, plot_total=True, 
+            legend_on=True, legend_frame_on=False, legend_cutoff=3., gaussian=None, 
+            height=6., width=8., xmin=-6., xmax=6., num_columns=2, colours=None, 
+            yscale=1, xlabel='Energy (eV)', ylabel='Arb. units',
             style=None, no_base_style=False,
             image_format='pdf', dpi=400, plt=None, fonts=None):
     """A script to plot the density of states from a vasprun.xml file.
@@ -92,6 +92,8 @@ def dosplot(filename=None, code='vasp', prefix=None, directory=None,
 
             If ``atoms`` is not set or set to ``None`` then all atomic sites
             for all elements will be considered.
+        spin (:obj:`bool`, optional): Plot a spin-polarised density of states,
+            spin up or spin down only. Defaults to ``None``.
         subplot (:obj:`bool`, optional): Plot the density of states for each
             element on separate subplots. Defaults to ``False``.
         shift (:obj:`bool`, optional): Shift the energies such that the valence
@@ -214,7 +216,7 @@ def dosplot(filename=None, code='vasp', prefix=None, directory=None,
                            xlabel=xlabel, ylabel=ylabel,
                            legend_cutoff=legend_cutoff, dpi=dpi, plt=plt,
                            fonts=fonts, style=style,
-                           no_base_style=no_base_style)
+                           no_base_style=no_base_style, spin=spin)
 
     if save_files:
         basename = 'dos.{}'.format(image_format)
@@ -303,6 +305,8 @@ def _get_parser():
                               'contributions (e.g. "Ru.d")'))
     parser.add_argument('-a', '--atoms', type=_atoms, metavar='A',
                         help=('atoms to include (e.g. "O.1.2.3,Ru.1.2.3")'))
+    parser.add_argument('--spin', type=str, default=None 
+                        help=('select spin for spin-polarised DOS'))
     parser.add_argument('-s', '--subplot', action='store_true',
                         help='plot each element on separate subplots')
     parser.add_argument('-g', '--gaussian', type=float, metavar='G',
@@ -379,7 +383,7 @@ def main():
 
     dosplot(filename=args.filename, code=args.code, prefix=args.prefix,
             directory=args.directory, elements=args.elements,
-            lm_orbitals=args.orbitals, atoms=args.atoms,
+            lm_orbitals=args.orbitals, atoms=args.atoms, spin=args.spin
             subplot=args.subplot, shift=args.shift, total_only=args.total_only,
             plot_total=args.total, legend_on=args.legend,
             legend_frame_on=args.legend_frame,

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -92,8 +92,8 @@ def dosplot(filename=None, code='vasp', prefix=None, directory=None,
 
             If ``atoms`` is not set or set to ``None`` then all atomic sites
             for all elements will be considered.
-        spin (:obj:`bool`, optional): Plot a spin-polarised density of states,
-            spin up or spin down only. Defaults to ``None``.
+        spin (:obj:`str`, optional): Plot a spin-polarised density of states,
+            "up" for spin up only, "down" for spin down only. Defaults to ``None``.
         subplot (:obj:`bool`, optional): Plot the density of states for each
             element on separate subplots. Defaults to ``False``.
         shift (:obj:`bool`, optional): Shift the energies such that the valence
@@ -306,7 +306,7 @@ def _get_parser():
     parser.add_argument('-a', '--atoms', type=_atoms, metavar='A',
                         help=('atoms to include (e.g. "O.1.2.3,Ru.1.2.3")'))
     parser.add_argument('--spin', type=str, default=None 
-                        help=('select spin for spin-polarised DOS'))
+                        help=('select spin for spin-polarised DOS (options: up, down)'))
     parser.add_argument('-s', '--subplot', action='store_true',
                         help='plot each element on separate subplots')
     parser.add_argument('-g', '--gaussian', type=float, metavar='G',

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -383,7 +383,7 @@ def main():
 
     dosplot(filename=args.filename, code=args.code, prefix=args.prefix,
             directory=args.directory, elements=args.elements,
-            lm_orbitals=args.orbitals, atoms=args.atoms, spin=args.spin
+            lm_orbitals=args.orbitals, atoms=args.atoms, spin=args.spin,
             subplot=args.subplot, shift=args.shift, total_only=args.total_only,
             plot_total=args.total, legend_on=args.legend,
             legend_frame_on=args.legend_frame,

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -305,7 +305,7 @@ def _get_parser():
                               'contributions (e.g. "Ru.d")'))
     parser.add_argument('-a', '--atoms', type=_atoms, metavar='A',
                         help=('atoms to include (e.g. "O.1.2.3,Ru.1.2.3")'))
-    parser.add_argument('--spin', type=str, default=None 
+    parser.add_argument('--spin', type=str, default=None,
                         help=('select spin for spin-polarised DOS (options: up, down)'))
     parser.add_argument('-s', '--subplot', action='store_true',
                         help='plot each element on separate subplots')

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -92,8 +92,9 @@ def dosplot(filename=None, code='vasp', prefix=None, directory=None,
 
             If ``atoms`` is not set or set to ``None`` then all atomic sites
             for all elements will be considered.
-        spin (:obj:`str`, optional): Plot a spin-polarised density of states,
-            "up" for spin up only, "down" for spin down only. Defaults to ``None``.
+        spin (:obj:`str`, optional): Plot only one spin channel from a
+            spin-polarised calculation; "up" for spin up only, "down" for
+            spin down only. Defaults to ``None``.
         subplot (:obj:`bool`, optional): Plot the density of states for each
             element on separate subplots. Defaults to ``False``.
         shift (:obj:`bool`, optional): Shift the energies such that the valence
@@ -306,7 +307,8 @@ def _get_parser():
     parser.add_argument('-a', '--atoms', type=_atoms, metavar='A',
                         help=('atoms to include (e.g. "O.1.2.3,Ru.1.2.3")'))
     parser.add_argument('--spin', type=str, default=None,
-                        help=('select spin for spin-polarised DOS (options: up, down)'))
+                        help=('select one spin channel only for a spin-polarised '
+                              'calculation (options: up, down)'))
     parser.add_argument('-s', '--subplot', action='store_true',
                         help='plot each element on separate subplots')
     parser.add_argument('-g', '--gaussian', type=float, metavar='G',

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -41,9 +41,9 @@ __date__ = "April 9, 2018"
 
 def dosplot(filename=None, code='vasp', prefix=None, directory=None,
             elements=None, lm_orbitals=None, atoms=None, spin=None,
-            subplot=False, shift=True, total_only=False, plot_total=True, 
-            legend_on=True, legend_frame_on=False, legend_cutoff=3., gaussian=None, 
-            height=6., width=8., xmin=-6., xmax=6., num_columns=2, colours=None, 
+            subplot=False, shift=True, total_only=False, plot_total=True,
+            legend_on=True, legend_frame_on=False, legend_cutoff=3., gaussian=None,
+            height=6., width=8., xmin=-6., xmax=6., num_columns=2, colours=None,
             yscale=1, xlabel='Energy (eV)', ylabel='Arb. units',
             style=None, no_base_style=False,
             image_format='pdf', dpi=400, plt=None, fonts=None):

--- a/sumo/electronic_structure/bandstructure.py
+++ b/sumo/electronic_structure/bandstructure.py
@@ -281,7 +281,7 @@ def get_reconstructed_band_structure(list_bs, efermi=None):
 
 def string_to_spin(spin_string):
     """Function to convert 'spin' cli argument to pymatgen Spin object"""
-    if spin_string in ['up','Up','1']:
+    if spin_string in ['up','Up','1','+1']:
         return Spin.up
     elif spin_string in ['down','Down','-1']:
         return Spin.down

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -206,7 +206,7 @@ class SBSPlotter(BSPlotter):
                     c = 'C0'
                 else:
                     c = 'C1'
-                ax.plot(dists[nd], e, c=c, linestyle='--', zorder=2)
+                ax.plot(dists[nd], e, c=c, ls='-', zorder=2)
 
         self._maketicks(ax, ylabel=ylabel)
         self._makeplot(ax, plt.gcf(), data, zero_to_efermi=zero_to_efermi,

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -190,12 +190,12 @@ class SBSPlotter(BSPlotter):
                 ax.plot(dists[nd], e, ls='-', c=c, zorder=1)
 
         # Plot second spin channel if it exists and no spin selected
-        if self._bs.is_spin_polarized and spin == None:
+        if self._bs.is_spin_polarized and spin is None:
             for nd, nb in it.product(range(len(data['distances'])),
                                      range(self._nb_bands)):
                 e = eners[nd][str(Spin.down)][nb]
                 ax.plot(dists[nd], e, c='C0', linestyle='--', zorder=2)
-                
+
         # Plot spin-down if selected
         if self._bs.is_spin_polarized and spin == 'down':
             for nd, nb in it.product(range(len(data['distances'])),

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -56,9 +56,9 @@ class SBSPlotter(BSPlotter):
                  no_base_style=False, spin=None):
         """Get a :obj:`matplotlib.pyplot` object of the band structure.
 
-        If the system is spin polarised, and no spin has been specified, orange 
-        lines are spin up, dashed blue lines are spin down. For metals, all 
-        bands are coloured blue. For semiconductors, blue lines indicate 
+        If the system is spin polarised, and no spin has been specified, orange
+        lines are spin up, dashed blue lines are spin down. For metals, all
+        bands are coloured blue. For semiconductors, blue lines indicate
         valence bands and orange lines indicates conduction bands.
 
         Args:
@@ -178,7 +178,7 @@ class SBSPlotter(BSPlotter):
             # For spin-polarized calculations, colour spin up channel with C1
             # and overlay with C0 (dashed) spin down channel
 
-            if self._bs.is_spin_polarized and spin == None:
+            if self._bs.is_spin_polarized and spin is None:
                 c = 'C1'
             elif self._bs.is_metal() or np.all(is_vb[nb]):
                 c = 'C0'
@@ -228,8 +228,8 @@ class SBSPlotter(BSPlotter):
                            no_base_style=False, spin=None):
         """Get a :obj:`matplotlib.pyplot` of the projected band structure.
 
-        If the system is spin polarised, no spin has been specified and 
-        ``mode = 'rgb'`` spin up and spin down bands are differentiated by 
+        If the system is spin polarised, no spin has been specified and
+        ``mode = 'rgb'`` spin up and spin down bands are differentiated by
         solid and dashed lines, respectively.
         For the other modes, spin up and spin down are plotted separately.
 
@@ -357,7 +357,7 @@ class SBSPlotter(BSPlotter):
                 predictably.
             spin (:obj:`str`, optional): Plot a spin-polarised band structure,
                 "up" for spin up only, "down" for spin down only. Defaults to ``None``.
-                
+
         Returns:
             :obj:`matplotlib.pyplot`: The projected electronic band structure
             plot.

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -156,6 +156,10 @@ class SBSPlotter(BSPlotter):
         dists = data['distances']
         eners = data['energy']
 
+        if spin is not None and not self._bs.is_spin_polarized:
+            raise ValueError('Spin-selection only possible with spin-polarised '
+                             'calculation results')
+
         if spin == 'up':
             is_vb = self._bs.bands[Spin.up] <= self._bs.get_vbm()['energy']
         elif spin == 'down':
@@ -383,8 +387,8 @@ class SBSPlotter(BSPlotter):
         # Ensure we do spin up first, then spin down
         spins = sorted(self._bs.bands.keys(), key=lambda s: -s.value)
         if spin is not None and len(spins) == 1:
-            raise ValueError('Spin-selection only possible with spin-polarised \
-                             calculation results')
+            raise ValueError('Spin-selection only possible with spin-polarised '
+                             'calculation results')
         if spin == 'up':
             spins = [spins[0]]
         elif spin == 'down':

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -383,9 +383,9 @@ class SBSPlotter(BSPlotter):
         # Ensure we do spin up first, then spin down
         spins = sorted(self._bs.bands.keys(), key=lambda s: -s.value)
         if spin == 'up':
-            spins = spins[0]
+            spins = [spins[0]]
         elif spin == 'down':
-            spins = spins[1]
+            spins = [spins[1]]
 
         proj = get_projections_by_branches(self._bs, selection,
                                            normalise='select')

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -382,6 +382,9 @@ class SBSPlotter(BSPlotter):
 
         # Ensure we do spin up first, then spin down
         spins = sorted(self._bs.bands.keys(), key=lambda s: -s.value)
+        if spin is not None and len(spins) == 1:
+            raise ValueError('Spin-selection only possible with spin-polarised \
+                             calculation results')
         if spin == 'up':
             spins = [spins[0]]
         elif spin == 'down':

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -56,10 +56,10 @@ class SBSPlotter(BSPlotter):
                  no_base_style=False, spin=None):
         """Get a :obj:`matplotlib.pyplot` object of the band structure.
 
-        If the system is spin polarised, orange lines are spin up, dashed
-        blue lines are spin down. For metals, all bands are coloured blue. For
-        semiconductors, blue lines indicate valence bands and orange lines
-        indicates conduction bands.
+        If the system is spin polarised, and no spin has been specified, orange 
+        lines are spin up, dashed blue lines are spin down. For metals, all 
+        bands are coloured blue. For semiconductors, blue lines indicate 
+        valence bands and orange lines indicates conduction bands.
 
         Args:
             zero_to_efermi (:obj:`bool`): Normalise the plot such that the
@@ -225,11 +225,12 @@ class SBSPlotter(BSPlotter):
                            dpi=400, plt=None,
                            dos_plotter=None, dos_options=None, dos_label=None,
                            dos_aspect=3, aspect=None, fonts=None, style=None,
-                           no_base_style=False):
+                           no_base_style=False, spin=None):
         """Get a :obj:`matplotlib.pyplot` of the projected band structure.
 
-        If the system is spin polarised and ``mode = 'rgb'`` spin up and spin
-        down bands are differentiated by solid and dashed lines, respectively.
+        If the system is spin polarised, no spin has been specified and 
+        ``mode = 'rgb'`` spin up and spin down bands are differentiated by 
+        solid and dashed lines, respectively.
         For the other modes, spin up and spin down are plotted separately.
 
         Args:
@@ -354,7 +355,9 @@ class SBSPlotter(BSPlotter):
             no_base_style (:obj:`bool`, optional): Prevent use of sumo base
                 style. This can make alternative styles behave more
                 predictably.
-
+            spin (:obj:`str`, optional): Plot a spin-polarised band structure,
+                "up" for spin up only, "down" for spin down only. Defaults to ``None``.
+                
         Returns:
             :obj:`matplotlib.pyplot`: The projected electronic band structure
             plot.
@@ -379,6 +382,10 @@ class SBSPlotter(BSPlotter):
 
         # Ensure we do spin up first, then spin down
         spins = sorted(self._bs.bands.keys(), key=lambda s: -s.value)
+        if spin == 'up':
+            spins = spins[0]
+        elif spin == 'down':
+            spins = spins[1]
 
         proj = get_projections_by_branches(self._bs, selection,
                                            normalise='select')

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -58,7 +58,7 @@ class SDOSPlotter(object):
 
     def dos_plot_data(self, yscale=1, xmin=-6., xmax=6., colours=None,
                       plot_total=True, legend_cutoff=3, subplot=False,
-                      zero_to_efermi=True, cache=None):
+                      zero_to_efermi=True, cache=None, spin=None):
         """Get the plotting data.
 
         Args:
@@ -94,6 +94,8 @@ class SDOSPlotter(object):
                 "colours" dict. This defaults to the module-level
                 sumo.plotting.colour_cache object, but an empty dict can be
                 used as a fresh cache. This object will be modified in-place.
+            spin (:obj:`str`, optional): Check that spin-selection has not
+                been called for a closed-shell calculation.
 
         Returns:
             dict: The plotting data. Formatted with the following keys:
@@ -137,6 +139,9 @@ class SDOSPlotter(object):
         mask = (eners >= xmin - 0.05) & (eners <= xmax + 0.05)
         plot_data = {'mask': mask, 'energies': eners}
         spins = dos.densities.keys()
+        if spin is not None and len(spins) == 1:
+            raise ValueError('Spin-selection only possible with spin-polarised \
+                             calculation results')
 
         # Visibility cutoff based on scale of total plot even if it is hidden
         dmax = max([max(d[mask]) for d in dos.densities.values()])
@@ -254,7 +259,7 @@ class SDOSPlotter(object):
                                        colours=colours, plot_total=plot_total,
                                        legend_cutoff=legend_cutoff,
                                        subplot=subplot,
-                                       zero_to_efermi=zero_to_efermi)
+                                       zero_to_efermi=zero_to_efermi, spin=spin)
 
         if subplot:
             nplots = len(plot_data['lines'])

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -140,8 +140,8 @@ class SDOSPlotter(object):
         plot_data = {'mask': mask, 'energies': eners}
         spins = dos.densities.keys()
         if spin is not None and len(spins) == 1:
-            raise ValueError('Spin-selection only possible with spin-polarised \
-                             calculation results')
+            raise ValueError('Spin-selection only possible with spin-polarised'
+                             'calculation results')
 
         # Visibility cutoff based on scale of total plot even if it is hidden
         dmax = max([max(d[mask]) for d in dos.densities.values()])

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -192,7 +192,7 @@ class SDOSPlotter(object):
                  legend_on=True, num_columns=2, legend_frame_on=False,
                  legend_cutoff=3, xlabel='Energy (eV)', ylabel='Arb. units',
                  zero_to_efermi=True, dpi=400, fonts=None, plt=None,
-                 style=None, no_base_style=False):
+                 style=None, no_base_style=False, spin=None):
         """Get a :obj:`matplotlib.pyplot` object of the density of states.
 
         Args:
@@ -244,6 +244,8 @@ class SDOSPlotter(object):
             no_base_style (:obj:`bool`, optional): Prevent use of sumo base
                 style. This can make alternative styles behave more
                 predictably.
+            spin (:obj:`str`, optional): Plot a spin-polarised density of states,
+            "up" for spin up only, "down" for spin down only. Defaults to ``None``.
 
         Returns:
             :obj:`matplotlib.pyplot`: The density of states plot.
@@ -265,8 +267,14 @@ class SDOSPlotter(object):
         energies = plot_data['energies'][mask]
         fig = plt.gcf()
         lines = plot_data['lines']
-        spins = [Spin.up] if len(lines[0][0]['dens']) == 1 else \
-            [Spin.up, Spin.down]
+        if len(lines[0][0]['dens']) == 1:
+            spins = [Spin.up] 
+        elif spin = 'up':
+            spins = [Spin.up]
+        elif spin = 'down':
+            spins = [Spin.down]
+        else:
+            spins = [Spin.up, Spin.down]
 
         for i, line_set in enumerate(plot_data['lines']):
             if subplot:

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -287,14 +287,10 @@ class SDOSPlotter(object):
             else:
                 ax = plt.gca()
 
-            ax.set_ylim(plot_data['ymin'], plot_data['ymax'])
-            ax.set_xlim(xmin, xmax)
-
             for line, spin in itertools.product(line_set, spins):
                 if len(spins) == 1:
                     label = line['label']
                     densities = line['dens'][spin][mask]
-                    ax.set_ylim(0, plot_data['ymax'])
                 elif spin == Spin.up:
                     label = line['label']
                     densities = line['dens'][spin][mask]
@@ -306,6 +302,12 @@ class SDOSPlotter(object):
                                 alpha=line['alpha'])
                 ax.plot(energies, densities, label=label,
                         color=line['colour'])
+
+            ax.set_xlim(xmin, xmax)
+            if len(spins) == 1:
+                ax.set_ylim(0, plot_data['ymax'])
+            else:
+                ax.set_ylim(plot_data['ymin'], plot_data['ymax'])
 
             ax.tick_params(axis='y', labelleft=False)
             ax.yaxis.set_minor_locator(AutoMinorLocator(2))

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -269,9 +269,9 @@ class SDOSPlotter(object):
         lines = plot_data['lines']
         if len(lines[0][0]['dens']) == 1:
             spins = [Spin.up] 
-        elif spin = 'up':
+        elif spin == 'up':
             spins = [Spin.up]
-        elif spin = 'down':
+        elif spin == 'down':
             spins = [Spin.down]
         else:
             spins = [Spin.up, Spin.down]

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -268,7 +268,7 @@ class SDOSPlotter(object):
         fig = plt.gcf()
         lines = plot_data['lines']
         if len(lines[0][0]['dens']) == 1:
-            spins = [Spin.up] 
+            spins = [Spin.up]
         elif spin == 'up':
             spins = [Spin.up]
         elif spin == 'down':
@@ -284,7 +284,7 @@ class SDOSPlotter(object):
 
             ax.set_ylim(plot_data['ymin'], plot_data['ymax'])
             ax.set_xlim(xmin, xmax)
-            
+
             for line, spin in itertools.product(line_set, spins):
                 if len(spins) == 1:
                     label = line['label']

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -282,8 +282,15 @@ class SDOSPlotter(object):
             else:
                 ax = plt.gca()
 
+            ax.set_ylim(plot_data['ymin'], plot_data['ymax'])
+            ax.set_xlim(xmin, xmax)
+            
             for line, spin in itertools.product(line_set, spins):
-                if spin == Spin.up:
+                if len(spins) == 1:
+                    label = line['label']
+                    densities = line['dens'][spin][mask]
+                    ax.set_ylim(0, plot_data['ymax'])
+                elif spin == Spin.up:
                     label = line['label']
                     densities = line['dens'][spin][mask]
                 elif spin == Spin.down:
@@ -294,9 +301,6 @@ class SDOSPlotter(object):
                                 alpha=line['alpha'])
                 ax.plot(energies, densities, label=label,
                         color=line['colour'])
-
-            ax.set_ylim(plot_data['ymin'], plot_data['ymax'])
-            ax.set_xlim(xmin, xmax)
 
             ax.tick_params(axis='y', labelleft=False)
             ax.yaxis.set_minor_locator(AutoMinorLocator(2))

--- a/sumo/plotting/dos_plotter.py
+++ b/sumo/plotting/dos_plotter.py
@@ -140,7 +140,7 @@ class SDOSPlotter(object):
         plot_data = {'mask': mask, 'energies': eners}
         spins = dos.densities.keys()
         if spin is not None and len(spins) == 1:
-            raise ValueError('Spin-selection only possible with spin-polarised'
+            raise ValueError('Spin-selection only possible with spin-polarised '
                              'calculation results')
 
         # Visibility cutoff based on scale of total plot even if it is hidden


### PR DESCRIPTION
I've added a 'spin' option to the CLI interface for _sumo-dosplot_ and _sumo-bandplot_, including _sumo-bandplot_ projected BS. The syntax is explained in the docstrings and help output: "spin (:obj:`str`, optional): Plot a spin-polarised band structure, "up" for spin up only, "down" for spin down only. Defaults to ``None``."  
I've checked that it works as it should.  
Examples:  
Spin-polarised DOS (Before Changes)  
![spinpoldosorig](https://user-images.githubusercontent.com/51478689/69919592-76336e80-1476-11ea-8413-c40fea96ff09.png)  
Spin-polarised DOS, Spin Up Only (After Changes)  
![spinpoldownewspindownonly](https://user-images.githubusercontent.com/51478689/69919590-759ad800-1476-11ea-975e-a7d3f138d4b8.png)  
Spin-polarised DOS, Spin Down Only (After Changes)  
![spinpoldosnewspinuponly](https://user-images.githubusercontent.com/51478689/69919591-76336e80-1476-11ea-903b-c9763ac63fec.png)  

Spin-Polarised BS (Before Changes)  
![spinpolbandorig](https://user-images.githubusercontent.com/51478689/69919597-76cc0500-1476-11ea-968f-a16902c9fc21.png)  
Spin-Polarised BS, Spin Down Only (After Changes)  
![spinpolbandnewspindownonly](https://user-images.githubusercontent.com/51478689/69919595-76336e80-1476-11ea-993e-bb9ca956d11b.png)  
Spin-Polarised BS, Spin Up Only (After Changes)  
![spinpolbandnewspinuponly](https://user-images.githubusercontent.com/51478689/69919596-76cc0500-1476-11ea-879d-6619bdb7609c.png)  
Spin-Polarised BS with Projections (Spin Down Only)(After Changes)  
![spinpolprojbandnewspindownonly](https://user-images.githubusercontent.com/51478689/69919593-76336e80-1476-11ea-8fab-aee83de2ae2b.png)  
Spin-Polarised BS with Projections (Spin Up Only)(After Changes)  
![spinpolprojbandnewspinuponly](https://user-images.githubusercontent.com/51478689/69919594-76336e80-1476-11ea-947b-0d4ab070b23a.png)  


