### PR TITLE
Move `string_to_spin` function for API compatibility

### DIFF
--- a/sumo/cli/bandplot.py
+++ b/sumo/cli/bandplot.py
@@ -294,6 +294,7 @@ def bandplot(filenames=None, code='vasp', prefix=None, directory=None,
     if scissor:
         bs = bs.apply_scissor(scissor)
 
+    spin = string_to_spin(spin) # Convert spin argument to pymatgen Spin object
     plotter = SBSPlotter(bs)
     if projection_selection:
         plt = plotter.get_projected_plot(
@@ -481,7 +482,7 @@ def _get_parser():
                               'contributions (e.g. "Ru.d")'))
     parser.add_argument('--atoms', type=_atoms, metavar='A',
                         help=('atoms to include (e.g. "O.1.2.3,Ru.1.2.3")'))
-    parser.add_argument('--spin', type=string_to_spin, default=None,
+    parser.add_argument('--spin', type=str, default=None,
                         help=('select only one spin channel for a spin-polarised '
                               'calculation (options: up, 1; down, -1)'))
     parser.add_argument('--scissor', type=float, default=None, dest='scissor',

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -209,6 +209,7 @@ def dosplot(filename=None, code='vasp', prefix=None, directory=None,
 
     save_files = False if plt else True  # don't save if pyplot object provided
 
+    spin = string_to_spin(spin) # Convert spin argument to pymatgen Spin object
     plotter = SDOSPlotter(dos, pdos)
     plt = plotter.get_plot(subplot=subplot, width=width, height=height,
                            xmin=xmin, xmax=xmax, yscale=yscale,
@@ -307,7 +308,7 @@ def _get_parser():
                               'contributions (e.g. "Ru.d")'))
     parser.add_argument('-a', '--atoms', type=_atoms, metavar='A',
                         help=('atoms to include (e.g. "O.1.2.3,Ru.1.2.3")'))
-    parser.add_argument('--spin', type=string_to_spin, default=None,
+    parser.add_argument('--spin', type=str, default=None,
                         help=('select one spin channel only for a spin-polarised '
                               'calculation (options: up, 1; down, -1)'))
     parser.add_argument('-s', '--subplot', action='store_true',

--- a/sumo/electronic_structure/bandstructure.py
+++ b/sumo/electronic_structure/bandstructure.py
@@ -285,5 +285,7 @@ def string_to_spin(spin_string):
         return Spin.up
     elif spin_string in ['down','Down','-1']:
         return Spin.down
+    elif spin_string in None:
+        return None
     else:
         raise ValueError("Unable to parse 'spin' argument")


### PR DESCRIPTION
Following on from issue #94 , I've moved the `string_to_spin` function (which accepts the `--spin` argument and converts to a pymatgen Spin object) from the `parser.add_argument` call (in which it was implemented as the `type` parameter) to just before the `get_plot` calls in `dosplot` and `bandplot`. The `type` parameter in  `parser.add_argument` (for `dosplot` and `bandplot`) is now just `str`, so the conversion of the `spin` argument via the `string_to_spin` function now takes place just before the `get_plot` calls in `dosplot` and `bandplot`. This ensures that the `spin` argument is correctly parsed and converted for both cli usage and for Python API usage of `dosplot` and/or `bandplot` (as was the issue in this case). I've also made the `string_to_spin` function capable of accepting `None` as an argument as well, so that it doesn't throw up an error if no spin is selected.

I've checked that both the cli and API implementations of `dosplot` and `bandplot` works as expected for all possible `spin` arguments (i.e. no selection, up or down) .