### PR TITLE
Rearrange `elif` to check 'if metal' before spin-selection

### DIFF
--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -162,10 +162,10 @@ class SBSPlotter(BSPlotter):
             raise ValueError('Spin-selection only possible with spin-polarised '
                              'calculation results')
 
-        elif spin is not None:
-            is_vb = self._bs.bands[spin] <= self._bs.get_vbm()['energy']
         elif self._bs.is_spin_polarized or self._bs.is_metal():
             is_vb = [True]
+        elif spin is not None:
+            is_vb = self._bs.bands[spin] <= self._bs.get_vbm()['energy']
         else:
             is_vb = self._bs.bands[Spin.up] <= self._bs.get_vbm()['energy']
 


### PR DESCRIPTION
Not sure if you want to do this fix differently @utf, but here's a suggestion. I believe all that is needed is to change the ordering of the `elif` statements, so that 'if metal' comes before spin-selection when setting the truth value of `is_vb`. Also, `get_vbm()` is not called in `dosplot`, so I think this is all that needs to be changed.