### PR TITLE
BUGFIX: Write primitive cell from kgen when using CASTEP

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ New features:
   - phonon-bandplot: phonon band structures from .phonon files
   - dosplot: total-DOS plotting from eigenvalues. Again,
     projected-DOS plots are not currently available.
+    
+Bug fixes:
+
+- Fix an oversight in the initial CASTEP/kgen implementation when the user provides a non-primitive cell as input.
 
 `[v1.4.0] <https://github.com/smtg-ucl/sumo/compare/v1.3.0...v1.4.0>`_ - 2020-01-25
 -----------------------------------------------------------------------------------

--- a/sumo/cli/kgen.py
+++ b/sumo/cli/kgen.py
@@ -160,6 +160,9 @@ def kgen(filename='POSCAR', code='vasp',
         prim_filename = '{}_prim'.format(os.path.basename(filename))
         if code.lower() == 'questaal':
             QuestaalInit.from_structure(kpath.prim).to_file(prim_filename)
+        elif code.lower() == 'castep':
+            CastepCell.from_structure(kpath.prim).to_file(prim_filename)
+
         else:
             kpath.prim.to(filename=prim_filename)
 

--- a/sumo/io/castep.py
+++ b/sumo/io/castep.py
@@ -30,6 +30,7 @@ Block = collections.namedtuple('Block', 'values comments')
 
 unsupported_dosplot_args = {'elements', 'lm_orbitals', 'atoms'}
 
+
 class CastepCell(object):
     """Structure information and more: CASTEP seedname.cell file
 
@@ -195,6 +196,19 @@ class CastepCell(object):
 
         return cls(tags=tags, blocks=blocks)
 
+    @classmethod
+    def from_structure(cls, structure):
+        blocks = {'lattice_cart': Block([['ang']]
+                                        + [list(map(str, row))
+                                           for row in
+                                           structure.lattice.matrix],
+                                        ['', '', '', '']),
+                  'positions_frac': Block([[site.species_string,
+                                            *map(str, site.frac_coords)]
+                                           for site in structure.sites],
+                                           ['' for site in structure.sites])}
+        return cls(blocks=blocks)
+
 
 def read_tdos(bands_file, bin_width=0.01, gaussian=None,
               padding=None, emin=None, emax=None, efermi_to_vbm=True):
@@ -269,6 +283,7 @@ def read_tdos(bands_file, bin_width=0.01, gaussian=None,
 
     return dos
 
+
 def _is_metal(eigenvalues, efermi, tol=1e-5):
     # Detect if material is a metal by checking if bands cross efermi
     from itertools import chain
@@ -280,11 +295,13 @@ def _is_metal(eigenvalues, efermi, tol=1e-5):
     logging.info("Electronic structure appears to have a bandgap")
     return False
 
+
 def _get_vbm(eigenvalues, efermi):
     from itertools import chain
     occupied_states_by_band = (band[band < efermi]
                                for band in chain(*eigenvalues.values()))
     return max(chain(*occupied_states_by_band))
+
 
 def band_structure(bands_file, cell_file=None):
     """Convert band structure data from CASTEP to Pymatgen/Sumo format
@@ -353,9 +370,9 @@ def labels_from_cell(cell_file, phonon=False):
 
     if phonon:
         blockstart = re.compile(
-            r'^%block\s+phonon_fine_kpoint(s)?_(path|list)')
+            r'^%block\s+phonon(_fine)?_kpoint(s)?_(path|list)')
         blockend = re.compile(
-            r'^%endblock\s+phonon_fine_kpoint(s)?_(path|list)')
+            r'^%endblock\s+phonon(_fine)?_kpoint(s)?_(path|list)')
     else:
         blockstart = re.compile(
             r'^%block\s+(bs|spectral)_kpoint(s)?_(path|list)')
@@ -638,7 +655,6 @@ def write_kpoint_files(filename, kpoints, labels, make_folders=False,
             cell_file.to_file(os.path.join(split_folder,
                                            os.path.basename(filename)))
 
-
     else:
         for i, cell_file in enumerate(kpt_cell_files):
             if len(kpt_cell_files) > 1:
@@ -790,7 +806,6 @@ class CastepPhonon(object):
 
         """
         self.labels = labels_from_cell(filename, phonon=True)
-
 
     def get_band_structure(self):
         lattice = Lattice(self.header['cell'])
@@ -966,7 +981,7 @@ def read_phonon_bands(filename, header):
             #      2   1 -0.60969  0.0000  -0.1654  0.0000  0.7751  0.0000
             if not f.readline().strip() == 'Phonon Eigenvectors':
                 raise AssertionError()
-            if not 'X' in f.readline().split():
+            if 'X' not in f.readline().split():
                 raise AssertionError()
             for i_mode in range(header['n_branches']):
                 for i_ion in range(header['n_ions']):

--- a/tests/tests_io/test_castep.py
+++ b/tests/tests_io/test_castep.py
@@ -29,7 +29,10 @@ class CastepCellTestCase(unittest.TestCase):
         self.zns_singlepoint_cell = resource_filename(
             __name__,
             path_join('..', 'data', 'ZnS', 'zns-sp.cell'))
-
+        si_structure_file = resource_filename(
+            __name__,
+            path_join('..', 'data', 'Si', 'Si8.json'))
+        self.si_structure = Structure.from_file(si_structure_file)
 
     def test_castep_cell_null_init(self):
         null_cell = CastepCell()
@@ -60,6 +63,19 @@ class CastepCellTestCase(unittest.TestCase):
                                   [[0., 2.71, 2.71],
                                    [2.71, 0., 2.71],
                                    [2.71, 2.71, 0.]])
+
+    def test_castep_cell_from_structure(self):
+        cell = CastepCell.from_structure(self.si_structure)
+        self.assertEqual(cell.blocks['lattice_cart'].values,
+                         [['ang'],
+                          ['5.43', '0.0', '0.0'],
+                          ['0.0', '5.43', '0.0'],
+                          ['0.0', '0.0', '5.43']])
+        self.assertEqual(cell.blocks['positions_frac'].values[0],
+                         ['Si', '0.0', '0.0', '0.0'])
+        self.assertEqual(cell.blocks['positions_frac'].values[7],
+                         ['Si', '0.75', '0.75', '0.25'])
+
 
 class CastepBandStructureTestCaseNoSpin(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Bug reported in https://github.com/ajjackson/castep-sumo-tutorial/issues/1

The Castep implementation overlooked a block in kgen which writes a
primitive cell file when non-primitive input was provided. This should
be harder to overlook; consider implementing a more consistent
interface for additional codes?

Anyway, this PR adds a Structure importer to the CastepCell class in order to complete the required functionality. It's a bit inelegant.