### PR TITLE
Pass bandplot range to CASTEP DOS

### DIFF
--- a/sumo/cli/bandplot.py
+++ b/sumo/cli/bandplot.py
@@ -307,7 +307,7 @@ def bandplot(filenames=None, code='vasp', prefix=None, directory=None,
                                  total_only)
         elif code == 'castep':
             dos = read_castep_tdos(dos_file, gaussian=gaussian,
-                                   efermi_to_vbm=True)
+                                   efermi_to_vbm=True, emin=ymin, emax=ymax)
             pdos = {}
         dos_plotter = SDOSPlotter(dos, pdos)
         dos_opts = {'plot_total': plot_total, 'legend_cutoff': legend_cutoff,


### PR DESCRIPTION
Fix a bug reported by @jryates; when adding a DOS to a CASTEP band structure, the --ymin and --ymax values were not being passed to the DOS plotter. The results are not pretty:

![bad-band](https://user-images.githubusercontent.com/2511383/87779341-8d1bab00-c824-11ea-9f35-ed922a25b8ea.png)

Passing the options seems to clean this up:
![band](https://user-images.githubusercontent.com/2511383/87779562-e1268f80-c824-11ea-85f7-f3503ad12c76.png)
