### PR TITLE
Bugfix: remove spurious Exception from questaal band_structure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Change Log
 Unreleased
 ----------
 
+Bugfixes:
+
+- Questaal band structure import was consistently raising unnecessary Exception
+
+
 v2.2.2
 ------
 

--- a/sumo/io/questaal.py
+++ b/sumo/io/questaal.py
@@ -1000,7 +1000,6 @@ def band_structure(bnds_file, lattice, labels=None, alat=1, coords_are_cartesian
                 coords, lattice.reciprocal_lattice_crystallographic.matrix
             )
 
-    raise Exception(eigenvals)
     # Data in bnds file seems to always be Cartesian
     return BandStructureSymmLine(
         kpoints,


### PR DESCRIPTION
Presumably this was added for debugging, and accidentally included in a commit. My bad!

Error was reported by @badw 

The fact that this got through testing tells us that the testing could use some work! Still I'm inclined to push this out sooner rather than later, as currently Questaal band structures are broken in the PyPI release.

@utf is it ok if I do a quick merge and release for this?