### PR TITLE
Add option to plot absorption data as a function of wavelength

### DIFF
--- a/sumo/cli/optplot.py
+++ b/sumo/cli/optplot.py
@@ -82,7 +82,7 @@ def optplot(
         directory (:obj:`str`, optional): The directory in which to save files.
         gaussian (:obj:`float`): Standard deviation for gaussian broadening.
         band_gaps (:obj:`float`, :obj:`str` or :obj:`list`, optional): The band
-            gap as a :obj:`float`, plotted as a dashed line. If plotting
+            gap as a :obj:`float`, in eV, plotted as a dashed line. If plotting
             multiple spectra then a :obj:`list` of band gaps can be provided.
             Band gaps can be provided as a floating-point number or as a path
             to a *vasprun.xml* file. To skip over a line, set its bandgap to

--- a/sumo/cli/optplot.py
+++ b/sumo/cli/optplot.py
@@ -59,6 +59,7 @@ def optplot(
     dpi=400,
     plt=None,
     fonts=None,
+    units='eV'
 ):
     """A script to plot optical absorption spectra from VASP calculations.
 
@@ -116,6 +117,10 @@ def optplot(
         fonts (:obj:`list`, optional): Fonts to use in the plot. Can be a
             a single font, specified as a :obj:`str`, or several fonts,
             specified as a :obj:`list` of :obj:`str`.
+        units (:obj:`str`, optional): X-axis units for the plot. 'eV' for
+           energy in electronvolts or 'nm' for wavelength in nanometers.
+           Defaults to 'eV'.
+
 
     Returns:
         A matplotlib pyplot object.
@@ -250,6 +255,7 @@ def optplot(
         fonts=fonts,
         style=style,
         no_base_style=no_base_style,
+        units=units
     )
 
     if save_files:
@@ -415,6 +421,9 @@ def _get_parser():
         "--dpi", type=int, default=400, help="pixel density for image file"
     )
     parser.add_argument("--font", default=None, help="font to use")
+    parser.add_argument(
+        "--units", type=str, default='eV', help='x-axis units (options: eV or nm)'
+    )
     return parser
 
 
@@ -469,6 +478,7 @@ def main():
         style=args.style,
         no_base_style=args.no_base_style,
         fonts=args.font,
+        units=args.units
     )
 
 

--- a/sumo/plotting/optics_plotter.py
+++ b/sumo/plotting/optics_plotter.py
@@ -20,6 +20,9 @@ from sumo.plotting import (
 )
 
 
+def ev_to_nm(energy_ev):  # convert energy in eV to wavelength in nm
+    return 1239.84193 / energy_ev
+
 class SOpticsPlotter(object):
     """Class for plotting optical spectra.
 
@@ -124,6 +127,7 @@ class SOpticsPlotter(object):
         fonts=None,
         style=None,
         no_base_style=False,
+        units='eV'
     ):
         """Get a :obj:`matplotlib.pyplot` object of the optical spectra.
 
@@ -152,6 +156,10 @@ class SOpticsPlotter(object):
             no_base_style (:obj:`bool`, optional): Prevent use of sumo base
                 style. This can make alternative styles behave more
                 predictably.
+            units (:obj:`str`, optional): X-axis units for the plot. 'eV' for
+                energy in electronvolts or 'nm' for wavelength in nanometers.
+                Defaults to 'eV'.
+
 
         Returns:
             :obj:`matplotlib.pyplot`: The plot of optical spectra.
@@ -204,10 +212,17 @@ class SOpticsPlotter(object):
             range(n_plots), self._spec_data.items(), ymin_series, ymax_series
         ):
             ax = fig.axes[i]
-            _plot_spectrum(data, self._label, self._band_gap, ax, optics_colours)
+            _plot_spectrum(data, self._label, self._band_gap, ax, optics_colours, units)
 
-            xmax = xmax if xmax else self._xmax
-            ax.set_xlim(xmin, xmax)
+            if not xmax and units in ['ev', 'eV']:
+                xmax = self._xmax  # use sumo-determined energy limits
+                ax.set_xlim(xmin, xmax)
+            elif units == 'nm':
+                xmax = xmax if xmax else 2500  # use default minimum energy (max wavelength) of
+                # 2500 nm
+                xmin = xmin if xmin else ev_to_nm(
+                    self._xmax)  # convert sumo-determined max energy to min wavelength
+                ax.set_xlim(xmin, xmax)
 
             if ymin is None and spectrum_key in (
                 "absorption",
@@ -251,7 +266,8 @@ class SOpticsPlotter(object):
                 ):
                     ax.legend(loc="best", frameon=False, ncol=1)
 
-        ax.set_xlabel("Energy (eV)")
+        xlabel = 'Energy (eV)' if units == 'eV' else 'Wavelength (nm)'
+        ax.set_xlabel(xlabel)
 
         # If only one plot, fix aspect ratio to match canvas
         if len(self._spec_data) == 1:
@@ -268,11 +284,15 @@ class SOpticsPlotter(object):
         return plt
 
 
-def _plot_spectrum(data, label, band_gap, ax, optics_colours):
+def _plot_spectrum(data, label, band_gap, ax, optics_colours, units):
     for (ener, alpha), abs_label, bg, c in zip(data, label, band_gap, optics_colours):
         if len(alpha.shape) == 1:
             # if averaged optics only plot one line
-            ax.plot(ener, alpha, label=abs_label, c=c)
+            if units == 'eV':
+                ax.plot(ener, alpha, label=abs_label, c=c)
+            elif units == 'nm':  # only for energies greater than 1 meV, to avoid RuntimeWarnings
+                # when converting to nm
+                ax.plot(ev_to_nm(ener[ener > 0.001]), alpha[ener > 0.001], label=abs_label, c=c)
 
         else:
             data = zip(range(3), ["xx", "yy", "zz"], ["-", "--", "-."])
@@ -284,7 +304,16 @@ def _plot_spectrum(data, label, band_gap, ax, optics_colours):
                     label = r"{}$_\mathregular{{{}}}$"
                     label = label.format(abs_label, direction_label)
 
-                ax.plot(ener, alpha[:, direction_id], ls=ls, label=label, c=c)
+                if units == 'eV':
+                    ax.plot(ener, alpha[:, direction_id], ls=ls,
+                            label=label, c=c)
+                elif units == 'nm':  # only for energies greater than 1 meV,
+                    # to avoid RuntimeWarnings when converting to nm
+                    ax.plot(ev_to_nm(ener[ener > 0.001]), alpha[ener > 0.001, direction_id],
+                            ls=ls, label=label, c=c)
         if bg:
             # plot band gap line
-            ax.axvline(bg, ls=":", c=c)
+            if units == 'eV':
+                ax.axvline(bg, ls=':', c=c)
+            elif units == 'nm':
+                ax.axvline(ev_to_nm(bg), ls=':', c=c)

--- a/sumo/plotting/optics_plotter.py
+++ b/sumo/plotting/optics_plotter.py
@@ -7,6 +7,7 @@ This module provides a class for plotting optical absorption spectra.
 """
 
 import numpy as np
+import scipy.constants as scpc
 from matplotlib import rcParams
 from matplotlib.font_manager import FontProperties, findfont
 from matplotlib.ticker import AutoMinorLocator, FuncFormatter, MaxNLocator
@@ -21,7 +22,7 @@ from sumo.plotting import (
 
 
 def ev_to_nm(energy_ev):  # convert energy in eV to wavelength in nm
-    return 1239.84193 / energy_ev
+    return 1e9*(scpc.h*scpc.c) / (energy_ev*scpc.electron_volt)
 
 class SOpticsPlotter(object):
     """Class for plotting optical spectra.
@@ -214,13 +215,13 @@ class SOpticsPlotter(object):
             ax = fig.axes[i]
             _plot_spectrum(data, self._label, self._band_gap, ax, optics_colours, units)
 
-            if units in ['ev', 'eV'] and not xmax:
+            if units in ['ev', 'eV'] and xmax is not None:
                 xmax = self._xmax  # use sumo-determined energy limits
             elif units == 'nm':
-                xmax = xmax if xmax else 2500  # use default minimum energy (max wavelength) of
-                # 2500 nm
-                xmin = xmin if xmin else ev_to_nm(
-                    self._xmax)  # convert sumo-determined max energy to min wavelength
+                # use default minimum energy (max wavelength) of 2500 nm
+                xmax = xmax if xmax is not None else 2500
+                # convert sumo-determined max energy to min wavelength
+                xmin = xmin if xmin else ev_to_nm(self._xmax)
             ax.set_xlim(xmin, xmax)
 
             if ymin is None and spectrum_key in (

--- a/sumo/plotting/optics_plotter.py
+++ b/sumo/plotting/optics_plotter.py
@@ -214,15 +214,14 @@ class SOpticsPlotter(object):
             ax = fig.axes[i]
             _plot_spectrum(data, self._label, self._band_gap, ax, optics_colours, units)
 
-            if not xmax and units in ['ev', 'eV']:
+            if units in ['ev', 'eV'] and not xmax:
                 xmax = self._xmax  # use sumo-determined energy limits
-                ax.set_xlim(xmin, xmax)
             elif units == 'nm':
                 xmax = xmax if xmax else 2500  # use default minimum energy (max wavelength) of
                 # 2500 nm
                 xmin = xmin if xmin else ev_to_nm(
                     self._xmax)  # convert sumo-determined max energy to min wavelength
-                ax.set_xlim(xmin, xmax)
+            ax.set_xlim(xmin, xmax)
 
             if ymin is None and spectrum_key in (
                 "absorption",


### PR DESCRIPTION
Add option to `sumo-optplot` to plot the absorption data as a function of wavelength in nanometres, as is commonly done experimentally.

Tested and all seems to behave as expected.

EG: `sumo-optplot --ymax 1.2e6 --units nm --xmax 2000 --xmin 300 -g 0.1 --bandgap 1.4` gives:
![image](https://user-images.githubusercontent.com/51478689/115076009-de5fe480-9ef3-11eb-9bfe-c8880610dd0d.png)

while `sumo-optplot --ymax 1.2e6 --xmax 4.13 --xmin 0.62 -g 0.1 -b 1.4` (same energy range) gives:
![image](https://user-images.githubusercontent.com/51478689/115077042-51b62600-9ef5-11eb-9d6f-0884d82ecbcb.png)
