### PR TITLE
Fix k-point indicies in sumo-bandstats

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+Bugfixes:
+
+- `sumo-bandstats` now reports the correct k-point indices for the VBM and CBM.
+
+
 v2.3.1
 ------
 

--- a/sumo/cli/bandstats.py
+++ b/sumo/cli/bandstats.py
@@ -96,7 +96,7 @@ def bandstats(
         vr = BSVasprun(vr_file, parse_projected_eigen=False)
         bs = vr.get_band_structure(line_mode=True)
         bandstructures.append(bs)
-    bs = get_reconstructed_band_structure(bandstructures)
+    bs = get_reconstructed_band_structure(bandstructures, force_kpath_branches=False)
 
     if bs.is_metal():
         logging.error("ERROR: System is metallic!")

--- a/sumo/electronic_structure/bandstructure.py
+++ b/sumo/electronic_structure/bandstructure.py
@@ -192,7 +192,7 @@ def get_projections(bs, selection, normalise=None):
     return spec_proj
 
 
-def get_reconstructed_band_structure(list_bs, efermi=None):
+def get_reconstructed_band_structure(list_bs, efermi=None, force_kpath_branches=True):
     """Combine a list of band structures into a single band structure.
 
     This is typically very useful when you split non self consistent
@@ -210,6 +210,8 @@ def get_reconstructed_band_structure(list_bs, efermi=None):
         efermi (:obj:`float`, optional): The Fermi energy of the reconstructed
             band structure. If `None`, an average of all the Fermi energies
             across all band structures is used.
+        force_kpath_branches (bool): Force a linemode band structure to contain
+            branches by adding repeated high-symmetry k-points in the path.
 
     Returns:
         :obj:`pymatgen.electronic_structure.bandstructure.BandStructure` or \
@@ -244,7 +246,10 @@ def get_reconstructed_band_structure(list_bs, efermi=None):
         structure=list_bs[0].structure,
         projections=projections,
     )
-    return force_branches(bs)
+    if force_kpath_branches:
+        return force_branches(bs)
+    else:
+        return bs
 
 
 def force_branches(bandstructure):


### PR DESCRIPTION
 The pymatgen logic for extracting branches in the band structure requires duplicating the high-symmetry points. To avoid wasting compute resources on these extra points, sumo-bandplot/bandstats adds this points dynamically rather than including them in the DFT calculation.

However, this means `sumo-bandstats` reports the wrong indices for the VBM and CBM with respect to the band structure calculation. This PR fixes this behaviour.

Fixes: #167 