### PR TITLE
Set band-edge marker size in style file

### DIFF
--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -726,9 +726,9 @@ class SBSPlotter(BSPlotter):
 
         if vbm_cbm_marker:
             for cbm in data["cbm"]:
-                ax.scatter(cbm[0], cbm[1], color="C2", marker="o", s=100)
+                ax.scatter(cbm[0], cbm[1], color="C2", marker="o")
             for vbm in data["vbm"]:
-                ax.scatter(vbm[0], vbm[1], color="C3", marker="o", s=100)
+                ax.scatter(vbm[0], vbm[1], color="C3", marker="o")
 
         if dos_plotter:
             ax = fig.axes[1]

--- a/sumo/plotting/sumo_bs.mplstyle
+++ b/sumo/plotting/sumo_bs.mplstyle
@@ -1,4 +1,6 @@
 xtick.bottom         : True
 ytick.right          : True
 
+lines.markersize: 10
+
 axes.prop_cycle : cycler('color', ['3953a4', 'faa316', 'd93b2b', '0db14b', 'f0a3ff', '0075dc', '993f00', '4c005c', '426600', 'ff0010', '9dcc00', 'c20088', '003380', 'ffa405', 'ffff00', 'ff5005', '5ef1f2', '740aff', '990000', '00998f', '005c31', '2bce48', 'ffcc99', '94ffb5', '8f7c00', '6fa8bb', '808080'])


### PR DESCRIPTION
Raised in #192 ; how can users adjust the size of VBM/CBM markers? This is currently hard-coded but does not need to be.

The CBM/VBM edge markers are plotted with `scatter`, which has a default marker size of s = rcParams['lines.markersize'] ** 2.

Our hard-coded `s=100` is rather chunky, so by replacing this with an equivalent value in the style file we allow users to customize it.