### PR TITLE
Fix optplot superscript

### DIFF
--- a/sumo/plotting/__init__.py
+++ b/sumo/plotting/__init__.py
@@ -169,7 +169,7 @@ def power_tick(val, pos, times_sign=r"\times"):
     coeff = val / 10**exponent
     prec = 0 if coeff % 1 == 0 else 1
 
-    return rf"$\mathregular{{{coeff:.{prec}f} {times_sign} 10^{exponent:2d}}}$"
+    return rf"${coeff:.{prec}f}\mathrm{{{times_sign}}}10^{{{exponent:2d}}}$"
 
 
 def colorline(

--- a/sumo/plotting/optics_plotter.py
+++ b/sumo/plotting/optics_plotter.py
@@ -243,12 +243,8 @@ class SOpticsPlotter:
 
             if spectrum_key == "absorption":
                 font = findfont(FontProperties(family=["sans-serif"]))
-                if "Whitney" in font:
-                    times_sign = "x"
-                else:
-                    times_sign = r"\times"
                 ax.yaxis.set_major_formatter(
-                    FuncFormatter(curry_power_tick(times_sign=times_sign))
+                    FuncFormatter(curry_power_tick(times_sign=r"\times"))
                 )
 
             ax.yaxis.set_major_locator(MaxNLocator(5))


### PR DESCRIPTION
Example of old optplot output:
<img width="343" alt="Screenshot 2023-03-29 at 12 42 17" src="https://user-images.githubusercontent.com/1330638/228524862-f15d3388-1275-4f75-aa0b-c4f1bfff8f31.png">


Example of fixed output:
<img width="340" alt="Screenshot 2023-03-29 at 12 41 49" src="https://user-images.githubusercontent.com/1330638/228524756-b58d357d-885f-45b0-b846-557328f211f2.png">
