### PR TITLE
Update release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,34 +8,34 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sumo
+    permissions:
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.14
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools setuptools_scm wheel
-          pip install numpy
-          pip install -e .
-          pip install -e .[tests]
+          python -m pip install build
+          pip install .[tests]
 
       - name: Test
         run: pytest
 
       - name: Build packages
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Write release info
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,7 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/sumo
-    permissions:
-      id-token: write
+    permissions: write-all
 
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,12 @@
 Change Log
 ==========
 
-Unreleased
-----------
+v2.4.0
+------
 
 Requirements:
+
+- New build system requires a recent Setuptools: this should be managed at build-time by any reasonably modern Pip or equivalent.
 
 - Bump minimum supported Python version to 3.10, in line with upstream Python support. (https://devguide.python.org/versions/)
 
@@ -14,6 +16,11 @@ Requirements:
 Bugfixes:
 
 - Handle API changes in Phonopy, Monty
+
+Maintenance:
+
+- Modernised build system, replacing *setup.py* with *pyproject.toml*
+- Update CI pipelines to test with Python 3.10, 3.11, 3.14
 
 v2.3.11
 -------

--- a/sumo/__init__.py
+++ b/sumo/__init__.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the MIT License.
 
 """
-Sumo is a set of scripts and an API for dealing with VASP output files.
+Sumo is a set of tools for plotting electronic structure calculations.
 """
 
-__version__ = "2.3.11"
+__version__ = "2.4.0"

--- a/sumo/__init__.py
+++ b/sumo/__init__.py
@@ -5,4 +5,4 @@
 Sumo is a set of tools for plotting electronic structure calculations.
 """
 
-__version__ = "2.4.0"
+__version__ = "2.4.0.post1"


### PR DESCRIPTION
The release action was on an older python. I also updated it to use more modern/recommended PyPI authentication (i.e. the action is whitelisted from PyPI side and doesn't use a password from `secrets`.)

That succeeded in building and pushing to PyPI, but failed to create a Github release 🤦 

https://github.com/SMTG-Bham/sumo/actions/runs/24199863780/job/70640200234

I think I need to set "write-all" permission instead of "write": https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac

Given that the release is on PyPI the correct cleanup option is probably to create a manual release on Github now.

I'll also update the permission to "write-all" here, which _hopefully_ will fix it next time.